### PR TITLE
(fix) allow output to suspend keys it has lifted

### DIFF
--- a/src/keyszer/output.py
+++ b/src/keyszer/output.py
@@ -71,6 +71,9 @@ class Output:
         print(self._pressed_modifier_keys)
         print("_pressed_keys")
         print(self._pressed_keys)
+        print("_suspended_mod_keys")
+        print(self._suspended_mod_keys)
+        print("_suspend_depth", self._suspend_depth)
 
     def __send_sync(self ):
         _uinput.syn()

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -508,8 +508,7 @@ def handle_commands(commands, key, action, input_combo = None):
     if is_suspended():
         resuspend_keys(_TIMEOUTS["suspend"])
 
-    _output.start_suspend()
-    try:
+    with _output.suspend_when_lifting():
         # Execute commands
         for command in commands:
             if callable(command):
@@ -544,5 +543,3 @@ def handle_commands(commands, key, action, input_combo = None):
             _next_bind = False
         # Reset keymap in ordinary flow
         return True
-    finally:
-        _output.stop_suspend()


### PR DESCRIPTION
Resolves #45.

This allows output to suspend keys it has lifted until the end of a *sequence* of combos, not just until the end of a single combo itself.  At the end of the sequence the keys that were suspended during the sequence will *immediately* be re-exerted on the output.