### PR TITLE
[draft] String and Unicode processing functions

### DIFF
--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -8,7 +8,7 @@ from inspect import signature
 from .lib.logger import error
 from .models.action import Action
 from .models.combo import Combo, ComboHint
-from .models.key import Key
+from .models.key import Key, ASCII_TO_KEY
 from .models.keymap import Keymap
 from .models.modifier import Modifier
 from .models.modmap import Modmap, MultiModmap
@@ -135,12 +135,10 @@ def usleep(usec):
 
 
 class CharacterNotSupported(Exception):
-    """Base class for other exceptions"""
     pass
 
 
 class TypingTooLong(Exception):
-    """Base class for other exceptions"""
     pass
 
 
@@ -155,12 +153,12 @@ def type(s):
             combo_list.append(C("Shift-" + c))
         elif ord(c) > 127:
             digits = hex(ord(c))[2:]
-            combos = unicode(digits)()
+            combos = unicode_combo(digits)()
             combo_list.extend(combos)
         elif (str.isalnum(c)):
             combo_list.append(Key[c.upper()])
-        elif c == " ":
-            combo_list.append(C("Space"))
+        elif c in ASCII_TO_KEY:
+            combo_list.append(ASCII_TO_KEY[c])
         else:
             raise CharacterNotSupported(f"The character {c} is not supported by `type` yet.")
 
@@ -171,7 +169,7 @@ def type(s):
 
 
 # TODO: should input here be a hexadecimal value: 0x1cf93
-def unicode(hexstring):
+def unicode_combo(hexstring):
     """Turn Unicode address hex string into keystroke commands"""
     hexstring = hexstring.upper()
     # TODO: need exceptions, not printed errors...
@@ -189,9 +187,9 @@ def unicode(hexstring):
     combo_list.append(Key.ENTER)
 
     # TODO: workaround for command not always supporting lists
-    def _unicode():
+    def _unicode_combo():
         return combo_list
-    return _unicode
+    return _unicode_combo
 
 
 def combo(exp):  # pylint: disable=invalid-name

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -162,6 +162,8 @@ def to_keystrokes(s):
             combo_list.append(Key[c.upper()])
         elif c in ASCII_TO_KEY:
             combo_list.append(ASCII_TO_KEY[c])
+        elif c in ASCII_WITH_SHIFT:
+            combo_list.append(ASCII_WITH_SHIFT[c])
         else:
             raise CharacterNotSupported(f"The character {c} is not supported by `to_keystrokes` yet.")
 
@@ -222,6 +224,31 @@ def _create_modifiers_from_strings(modifier_strs):
         if key not in modifiers:
             modifiers.append(key)
     return modifiers
+
+
+ASCII_WITH_SHIFT = {
+    "~":    combo("Shift-Grave"),
+    "!":    combo("Shift-1"),
+    "@":    combo("Shift-2"),
+    "#":    combo("Shift-3"),
+    "$":    combo("Shift-4"),
+    "%":    combo("Shift-5"),
+    "^":    combo("Shift-6"),
+    "&":    combo("Shift-7"),
+    "*":    combo("Shift-8"),
+    "(":    combo("Shift-9"),
+    ")":    combo("Shift-0"),
+    "_":    combo("Shift-Minus"),
+    "+":    combo("Shift-Equal"),
+    "{":    combo("Shift-Left_Brace"),
+    "}":    combo("Shift-Right_Brace"),
+    "|":    combo("Shift-Backslash"),
+    ":":    combo("Shift-Semicolon"),
+    "\"":   combo("Shift-Apostrophe"),
+    "<":    combo("Shift-Comma"),
+    ">":    combo("Shift-Dot"),
+    "?":    combo("Shift-Slash")
+}
 
 
 # ─── MARKS ──────────────────────────────────────────────────────────────────

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -153,11 +153,11 @@ def to_keystrokes(s):
 
     combo_list = []
     for c in s:
-        if c.isupper():
-            combo_list.append(combo("Shift-" + c))
-        elif ord(c) > 127:
+        if ord(c) > 127:
             combos = unicode_keystrokes(ord(c))
             combo_list.extend(combos)
+        elif c.isupper():
+            combo_list.append(combo("Shift-" + c))
         elif (str.isalnum(c)):
             combo_list.append(Key[c.upper()])
         elif c in ASCII_TO_KEY:

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -156,7 +156,7 @@ def to_keystrokes(s):
         if c.isupper():
             combo_list.append(combo("Shift-" + c))
         elif ord(c) > 127:
-            combos = unicode_keystrokes(ord(c))()
+            combos = unicode_keystrokes(ord(c))
             combo_list.extend(combos)
         elif (str.isalnum(c)):
             combo_list.append(Key[c.upper()])
@@ -165,10 +165,7 @@ def to_keystrokes(s):
         else:
             raise CharacterNotSupported(f"The character {c} is not supported by `type` yet.")
 
-    # TODO: workaround for command not always supporting lists
-    def _type():
-        return combo_list
-    return _type
+    return combo_list
 
 
 def _digits(n, base):
@@ -193,10 +190,7 @@ def unicode_keystrokes(n):
         Key.ENTER
     ]
 
-    # TODO: workaround for command not always supporting lists
-    def _unicode_combo():
-        return combo_list
-    return _unicode_combo
+    return combo_list
 
 
 def combo(exp):  # pylint: disable=invalid-name

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -1,5 +1,6 @@
 import itertools
 import re
+import string
 import sys
 import time
 from inspect import signature
@@ -131,6 +132,50 @@ def usleep(usec):
 
 
 # ============================================================ #
+
+
+def ST(str_to_type):
+    """Turn alphanumeric string (with spaces) up to length of 250 characters into keystroke commands"""
+    if len(str_to_type) >= 251:
+        print("ERROR: String too long. Use some other solution for strings longer than 250 characters.")
+        return
+    if (str.isalnum(str_to_type.replace(" ", ""))) != True:
+        print("ERROR: String contains non-alphanumeric characters. Not supported yet.")
+        return
+    combo_list = []
+    for c in str_to_type:
+        if c.isupper(): 
+            combo_list.append(C("Shift-" + c))
+        elif c == " ":
+            combo_list.append(C("Space"))
+        elif (str.isalpha(c)):
+            combo_list.append(C(c))
+        else:
+            combo_list.append(C("KEY_" + c))
+    def ascii_string_printer():
+        return combo_list
+    return ascii_string_printer
+
+
+def UC(unicode_address):
+    """Turn Unicode address hex string into keystroke commands"""
+    if (all(c in string.hexdigits for c in unicode_address) == False):
+        print("ERROR: Invalid Unicode address string. Must be hexadecimal, 1 to 6 characters.")
+        return
+    elif (len(unicode_address) >= 7 or len(unicode_address) < 1):
+        print("ERROR: Invalid Unicode address string. Must be 1 to 6 hex characters in length.")
+        return
+    combo_list = []
+    combo_list.append(C("Shift-Ctrl-u"))
+    for c in unicode_address:
+        if (str.isalpha(c)):
+            combo_list.append(C(c))            
+        else:
+            combo_list.append(C("KEY_" + c))
+    combo_list.append(K("Enter"))
+    def UC_printer():
+        return combo_list
+    return UC_printer
 
 
 def C(exp):  # pylint: disable=invalid-name

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -146,8 +146,12 @@ class UnicodeNumberToolarge(Exception):
     pass
 
 
-def to_keystrokes(s):
-    """Turn alphanumeric string (with spaces and some ASCII) up to length of 100 characters into keystroke commands"""
+def to_US_keystrokes(s):
+    """
+    Turn alphanumeric string (with spaces and some ASCII) up to length of 100 characters into keystroke commands
+
+    Warn: Almost certainly not going to work with non-US keymaps.
+    """
     if len(s) > 100:
         raise TypingTooLong("`to_keystrokes` only supports strings of 100 characters or less")
 

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -147,9 +147,9 @@ class UnicodeNumberToolarge(Exception):
 
 
 def to_keystrokes(s):
-    """Turn alphanumeric string (with spaces) up to length of 100 characters into keystroke commands"""
+    """Turn alphanumeric string (with spaces and some ASCII) up to length of 100 characters into keystroke commands"""
     if len(s) > 100:
-        raise TypingTooLong("`type` only supports strings of 100 characters or less")
+        raise TypingTooLong("`to_keystrokes` only supports strings of 100 characters or less")
 
     combo_list = []
     for c in s:
@@ -163,7 +163,7 @@ def to_keystrokes(s):
         elif c in ASCII_TO_KEY:
             combo_list.append(ASCII_TO_KEY[c])
         else:
-            raise CharacterNotSupported(f"The character {c} is not supported by `type` yet.")
+            raise CharacterNotSupported(f"The character {c} is not supported by `to_keystrokes` yet.")
 
     return combo_list
 

--- a/src/keyszer/lib/benchit.py
+++ b/src/keyszer/lib/benchit.py
@@ -2,10 +2,16 @@ import time
 
 
 def benchit(fn):
-    def fni(*args):
+    def fni(*args,**kwargs):
         a = time.perf_counter_ns()
-        fn(*args)
+        res = fn(*args, **kwargs)
         b = time.perf_counter_ns()
-        print((b - a) // 1000, "us")
+        tm = (b - a) // 1000
+        units = "us"
+        # if tm > 5000:
+        #     tm = round(tm / 1000, 1)
+        #     units = "ms"
+        print(fn.__name__, tm, units)
+        return res
 
     return fni

--- a/src/keyszer/models/key.py
+++ b/src/keyszer/models/key.py
@@ -741,3 +741,19 @@ class Key(IntEnum, metaclass=KeyMeta):
 
     def __str__(self):
         return self.name
+
+
+ASCII_TO_KEY = {
+    ";": Key.SEMICOLON,
+    "'": Key.APOSTROPHE,
+    "=": Key.EQUAL,
+    "-": Key.MINUS,
+    "`": Key.GRAVE,
+    "[": Key.LEFT_BRACE,
+    "]": Key.RIGHT_BRACE,
+    ",": Key.COMMA,
+    ".": Key.DOT,
+    "/": Key.SLASH,
+    " ": Key.SPACE,
+    "\\": Key.BACKSLASH
+}

--- a/src/keyszer/models/key.py
+++ b/src/keyszer/models/key.py
@@ -1,10 +1,23 @@
-from enum import IntEnum
+from enum import IntEnum, EnumMeta
 
 # fmt: off
 
 
+class KeyMeta(EnumMeta):
+    """
+    fix numerics being a special case and allows them to be accessed via
+    Key["1"] just like any other normal key
+    """
+    def __getitem__(self, key):
+        s = super()
+        if key in "0123456789":
+            return s.__getitem__(f"KEY_{key}")
+        else:
+            return s.__getitem__(key)
+
+
 # https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h
-class Key(IntEnum):
+class Key(IntEnum, metaclass=KeyMeta):
     """ representation of a single keyboard key"""
     RESERVED = 0
     ESC = 1

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -563,6 +563,10 @@ def handle_commands(commands, key, action, input_combo=None):
             elif isinstance(command, Keymap):
                 _active_keymaps = [command]
                 return False
+            elif isinstance(command, list):
+                reset_mode = handle_commands(command, key, action)
+                if reset_mode is False:
+                    return False
             elif command is None:
                 pass
             else:

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -563,6 +563,8 @@ def handle_commands(commands, key, action, input_combo=None):
             elif isinstance(command, Keymap):
                 _active_keymaps = [command]
                 return False
+            # to_keystrokes and unicode_keystrokes produce lists so
+            # we'll just handle it recursively
             elif isinstance(command, list):
                 reset_mode = handle_commands(command, key, action)
                 if reset_mode is False:

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -57,11 +57,11 @@ def test_combo_simple():
 
 def test_type_simple():
     out = to_keystrokes("hello5")
-    assert [Key.H, Key.E, Key.L, Key.L, Key.O, Key.KEY_5] == out()
+    assert [Key.H, Key.E, Key.L, Key.L, Key.O, Key.KEY_5] == out
 
 def test_type_simple_with_shift():
     out = to_keystrokes("Hello")
-    assert [C("Shift-H"), Key.E, Key.L, Key.L, Key.O] == out()
+    assert [C("Shift-H"), Key.E, Key.L, Key.L, Key.O] == out
 
 def test_type_unsupported_character():
     with pytest.raises(CharacterNotSupported) as e:
@@ -78,36 +78,36 @@ def test_type_extended_ascii():
     out = to_keystrokes("\u00ff")
     assert [ C("Shift-Ctrl-U"),
              Key.F, Key.F,
-             Key.ENTER] == out()
+             Key.ENTER] == out
 
 def test_ascii_keys():
     out = to_keystrokes("`-=[]\\;',./")
     assert [ Key.GRAVE, Key.MINUS, Key.EQUAL, Key.LEFT_BRACE,
              Key.RIGHT_BRACE, Key.BACKSLASH, Key.SEMICOLON,
              Key.APOSTROPHE, Key.COMMA, Key.DOT, Key.SLASH
-             ] == out()
+             ] == out
 
 def test_type_unicode():
     out = to_keystrokes("🎉")
     assert [ C("Shift-Ctrl-U"),
              Key.KEY_1, Key.F, Key.KEY_3, Key.KEY_8, Key.KEY_9,
-             Key.ENTER] == out()
+             Key.ENTER] == out
 
     out = to_keystrokes("\U0001f389")
     assert [ C("Shift-Ctrl-U"),
              Key.KEY_1, Key.F, Key.KEY_3, Key.KEY_8, Key.KEY_9,
-             Key.ENTER] == out()
+             Key.ENTER] == out
 
 def test_uncode_keystrokes():
     out = unicode_keystrokes(0x00ff)
     assert [ C("Shift-Ctrl-U"),
              Key.F, Key.F,
-             Key.ENTER] == out()
+             Key.ENTER] == out
 
     out = unicode_keystrokes(0x10fad)
     assert [ C("Shift-Ctrl-U"),
              Key.KEY_1, Key.KEY_0, Key.F, Key.A, Key.D,
-             Key.ENTER] == out()
+             Key.ENTER] == out
 
     with pytest.raises(UnicodeNumberToolarge) as e:
         out = unicode_keystrokes(0x110000)

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -87,6 +87,15 @@ def test_ascii_keys():
              Key.APOSTROPHE, Key.COMMA, Key.DOT, Key.SLASH
              ] == out
 
+def test_ascii_with_shift_keys():
+    out = to_keystrokes('~!@#$%^&*()_+{}|:"<>?')
+    assert [C("Shift-Grave"),C("Shift-1"),C("Shift-2"),C("Shift-3"),C("Shift-4"),
+            C("Shift-5"),C("Shift-6"),C("Shift-7"),C("Shift-8"),C("Shift-9"),
+            C("Shift-0"),C("Shift-Minus"),C("Shift-Equal"),C("Shift-Left_Brace"),
+            C("Shift-Right_Brace"),C("Shift-Backslash"),C("Shift-Semicolon"),
+            C("Shift-Apostrophe"),C("Shift-Comma"),C("Shift-Dot"),C("Shift-Slash")
+             ] == out
+
 def test_type_unicode():
     out = to_keystrokes("🎉")
     assert [ C("Shift-Ctrl-U"),

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -56,44 +56,59 @@ def test_combo_simple():
     assert [Modifier.ALT] == combo.modifiers
 
 def test_type_simple():
-    out = type("hello5")
+    out = to_keystrokes("hello5")
     assert [Key.H, Key.E, Key.L, Key.L, Key.O, Key.KEY_5] == out()
 
 def test_type_simple_with_shift():
-    out = type("Hello")
+    out = to_keystrokes("Hello")
     assert [C("Shift-H"), Key.E, Key.L, Key.L, Key.O] == out()
 
 def test_type_unsupported_character():
     with pytest.raises(CharacterNotSupported) as e:
-        out = type("{")
+        out = to_keystrokes("{")
         assert e.message == "The character { is not supported by `type` yet"
 
 def test_type_too_long():
     with pytest.raises(TypingTooLong) as e:
-        out = type("lasdjlkad jlkasjd laksjdlkasj dlkasj dlk ajlkd jaldkjal"
+        out = to_keystrokes("lasdjlkad jlkasjd laksjdlkasj dlkasj dlk ajlkd jaldkjal"
             "asdkjhasdkjahkjdhaskjdhakjdhkjadh kajhdkjashdkashdkjajhdajksd")
         assert e.message == "`type` only supports strings of 100 characters or less"
 
 def test_type_extended_ascii():
-    out = type("\u00ff")
+    out = to_keystrokes("\u00ff")
     assert [ C("Shift-Ctrl-U"),
              Key.F, Key.F,
              Key.ENTER] == out()
 
 def test_ascii_keys():
-    out = type("`-=[]\\;',./")
+    out = to_keystrokes("`-=[]\\;',./")
     assert [ Key.GRAVE, Key.MINUS, Key.EQUAL, Key.LEFT_BRACE,
              Key.RIGHT_BRACE, Key.BACKSLASH, Key.SEMICOLON,
              Key.APOSTROPHE, Key.COMMA, Key.DOT, Key.SLASH
              ] == out()
 
 def test_type_unicode():
-    out = type("🎉")
+    out = to_keystrokes("🎉")
     assert [ C("Shift-Ctrl-U"),
              Key.KEY_1, Key.F, Key.KEY_3, Key.KEY_8, Key.KEY_9,
              Key.ENTER] == out()
 
-    out = type("\U0001f389")
+    out = to_keystrokes("\U0001f389")
     assert [ C("Shift-Ctrl-U"),
              Key.KEY_1, Key.F, Key.KEY_3, Key.KEY_8, Key.KEY_9,
              Key.ENTER] == out()
+
+def test_uncode_keystrokes():
+    out = unicode_keystrokes(0x00ff)
+    assert [ C("Shift-Ctrl-U"),
+             Key.F, Key.F,
+             Key.ENTER] == out()
+
+    out = unicode_keystrokes(0x10fad)
+    assert [ C("Shift-Ctrl-U"),
+             Key.KEY_1, Key.KEY_0, Key.F, Key.A, Key.D,
+             Key.ENTER] == out()
+
+    with pytest.raises(UnicodeNumberToolarge) as e:
+        out = unicode_keystrokes(0x110000)
+        assert e.message == "too large for Unicode keyboard entry."

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -63,10 +63,13 @@ def test_type_simple_with_shift():
     out = to_US_keystrokes("Hello")
     assert [C("Shift-H"), Key.E, Key.L, Key.L, Key.O] == out
 
+# TODO: it wasn't clear what to use here since we support
+# - most all ASCII now so we went with BELL but this may
+# - just be better to remove in the future
 def test_type_unsupported_character():
     with pytest.raises(CharacterNotSupported) as e:
-        out = to_US_keystrokes("{")
-        assert e.message == "The character { is not supported by `type` yet"
+        out = to_US_keystrokes("\u0007")
+        assert e.message == "The character \u0007 is not supported by `type` yet"
 
 def test_type_too_long():
     with pytest.raises(TypingTooLong) as e:

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -56,39 +56,39 @@ def test_combo_simple():
     assert [Modifier.ALT] == combo.modifiers
 
 def test_type_simple():
-    out = to_keystrokes("hello5")
+    out = to_US_keystrokes("hello5")
     assert [Key.H, Key.E, Key.L, Key.L, Key.O, Key.KEY_5] == out
 
 def test_type_simple_with_shift():
-    out = to_keystrokes("Hello")
+    out = to_US_keystrokes("Hello")
     assert [C("Shift-H"), Key.E, Key.L, Key.L, Key.O] == out
 
 def test_type_unsupported_character():
     with pytest.raises(CharacterNotSupported) as e:
-        out = to_keystrokes("{")
+        out = to_US_keystrokes("{")
         assert e.message == "The character { is not supported by `type` yet"
 
 def test_type_too_long():
     with pytest.raises(TypingTooLong) as e:
-        out = to_keystrokes("lasdjlkad jlkasjd laksjdlkasj dlkasj dlk ajlkd jaldkjal"
+        out = to_US_keystrokes("lasdjlkad jlkasjd laksjdlkasj dlkasj dlk ajlkd jaldkjal"
             "asdkjhasdkjahkjdhaskjdhakjdhkjadh kajhdkjashdkashdkjajhdajksd")
         assert e.message == "`type` only supports strings of 100 characters or less"
 
 def test_type_extended_ascii():
-    out = to_keystrokes("\u00ff")
+    out = to_US_keystrokes("\u00ff")
     assert [ C("Shift-Ctrl-U"),
              Key.F, Key.F,
              Key.ENTER] == out
 
 def test_ascii_keys():
-    out = to_keystrokes("`-=[]\\;',./")
+    out = to_US_keystrokes("`-=[]\\;',./")
     assert [ Key.GRAVE, Key.MINUS, Key.EQUAL, Key.LEFT_BRACE,
              Key.RIGHT_BRACE, Key.BACKSLASH, Key.SEMICOLON,
              Key.APOSTROPHE, Key.COMMA, Key.DOT, Key.SLASH
              ] == out
 
 def test_ascii_with_shift_keys():
-    out = to_keystrokes('~!@#$%^&*()_+{}|:"<>?')
+    out = to_US_keystrokes('~!@#$%^&*()_+{}|:"<>?')
     assert [C("Shift-Grave"),C("Shift-1"),C("Shift-2"),C("Shift-3"),C("Shift-4"),
             C("Shift-5"),C("Shift-6"),C("Shift-7"),C("Shift-8"),C("Shift-9"),
             C("Shift-0"),C("Shift-Minus"),C("Shift-Equal"),C("Shift-Left_Brace"),
@@ -97,12 +97,12 @@ def test_ascii_with_shift_keys():
              ] == out
 
 def test_type_unicode():
-    out = to_keystrokes("🎉")
+    out = to_US_keystrokes("🎉")
     assert [ C("Shift-Ctrl-U"),
              Key.KEY_1, Key.F, Key.KEY_3, Key.KEY_8, Key.KEY_9,
              Key.ENTER] == out
 
-    out = to_keystrokes("\U0001f389")
+    out = to_US_keystrokes("\U0001f389")
     assert [ C("Shift-Ctrl-U"),
              Key.KEY_1, Key.F, Key.KEY_3, Key.KEY_8, Key.KEY_9,
              Key.ENTER] == out

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -80,6 +80,12 @@ def test_type_extended_ascii():
              Key.F, Key.F,
              Key.ENTER] == out()
 
+def test_ascii_keys():
+    out = type("`-=[]\\;',./")
+    assert [ Key.GRAVE, Key.MINUS, Key.EQUAL, Key.LEFT_BRACE,
+             Key.RIGHT_BRACE, Key.BACKSLASH, Key.SEMICOLON,
+             Key.APOSTROPHE, Key.COMMA, Key.DOT, Key.SLASH
+             ] == out()
 
 def test_type_unicode():
     out = type("🎉")

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -1,0 +1,93 @@
+import warnings
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+from evdev.ecodes import EV_KEY, EV_SYN
+from evdev.events import InputEvent
+from lib.api import *
+from lib.uinput_stub import UInputStub
+
+from keyszer import input
+from keyszer.config_api import *
+from keyszer.lib import logger
+from keyszer.models.action import Action
+from keyszer.models.key import Key
+from keyszer.output import setup_uinput
+from keyszer.transform import (
+    boot_config,
+    is_suspended,
+    on_event,
+    reset_transform,
+    resume_keys,
+    suspend_keys,
+)
+
+logger.VERBOSE = True
+import asyncio
+
+import pytest
+import pytest_asyncio
+
+_out = None
+
+def setup_function(module):
+    global _out
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    _out = UInputStub()
+    setup_uinput(_out)
+    reset_transform()
+    reset_configuration()
+
+
+def test_combo_single_letter():
+    combo = C("A")
+    assert Key.A == combo.key
+    assert [] == combo.modifiers
+
+def test_combo_single_simple_number():
+    combo = C("1")
+    assert Key.KEY_1 == combo.key
+    assert [] == combo.modifiers
+
+def test_combo_simple():
+    combo = C("Alt-A")
+    assert Key.A == combo.key
+    assert [Modifier.ALT] == combo.modifiers
+
+def test_type_simple():
+    out = type("hello5")
+    assert [Key.H, Key.E, Key.L, Key.L, Key.O, Key.KEY_5] == out()
+
+def test_type_simple_with_shift():
+    out = type("Hello")
+    assert [C("Shift-H"), Key.E, Key.L, Key.L, Key.O] == out()
+
+def test_type_unsupported_character():
+    with pytest.raises(CharacterNotSupported) as e:
+        out = type("{")
+        assert e.message == "The character { is not supported by `type` yet"
+
+def test_type_too_long():
+    with pytest.raises(TypingTooLong) as e:
+        out = type("lasdjlkad jlkasjd laksjdlkasj dlkasj dlk ajlkd jaldkjal"
+            "asdkjhasdkjahkjdhaskjdhakjdhkjadh kajhdkjashdkashdkjajhdajksd")
+        assert e.message == "`type` only supports strings of 100 characters or less"
+
+def test_type_extended_ascii():
+    out = type("\u00ff")
+    assert [ C("Shift-Ctrl-U"),
+             Key.F, Key.F,
+             Key.ENTER] == out()
+
+
+def test_type_unicode():
+    out = type("🎉")
+    assert [ C("Shift-Ctrl-U"),
+             Key.KEY_1, Key.F, Key.KEY_3, Key.KEY_8, Key.KEY_9,
+             Key.ENTER] == out()
+
+    out = type("\U0001f389")
+    assert [ C("Shift-Ctrl-U"),
+             Key.KEY_1, Key.F, Key.KEY_3, Key.KEY_8, Key.KEY_9,
+             Key.ENTER] == out()

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -261,3 +261,32 @@ async def test_real_inputs_do_not_reexert_during_combo_sequence():
         (RELEASE, Key.LEFT_CTRL),
         (RELEASE, Key.LEFT_ALT),
     ]
+
+async def test_simple_to_keystrokes():
+    keymap("default",{
+        K("C-j"): [Key.I, to_keystrokes("love"), Key.U]
+    })
+
+    boot_config()
+
+    press(Key.LEFT_CTRL)
+    press(Key.J)
+    release(Key.J)
+    release(Key.LEFT_CTRL)
+
+    # thanks to escaping with just get a B rather
+    # than the C-b combo
+    assert _out.keys() == [
+        (PRESS, Key.I),
+        (RELEASE, Key.I),
+        (PRESS, Key.L),
+        (RELEASE, Key.L),
+        (PRESS, Key.O),
+        (RELEASE, Key.O),
+        (PRESS, Key.V),
+        (RELEASE, Key.V),
+        (PRESS, Key.E),
+        (RELEASE, Key.E),
+        (PRESS, Key.U),
+        (RELEASE, Key.U),
+    ]

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -264,7 +264,7 @@ async def test_real_inputs_do_not_reexert_during_combo_sequence():
 
 async def test_simple_to_keystrokes():
     keymap("default",{
-        K("C-j"): [Key.I, to_keystrokes("love"), Key.U]
+        K("C-j"): [Key.I, to_US_keystrokes("love"), Key.U]
     })
 
     boot_config()


### PR DESCRIPTION
### Changes

Two new [draft] functions for processing simple alphanumeric strings (with spaces) and Unicode code point address references (between 1 and 6 hex characters). `ST()` for strings and `UC()` for Unicode addresses. Names will probably change. 

### Related issue thread

https://github.com/joshgoebel/keyszer/issues/43

