### PR TITLE
(enh) Support Capslock and Numlock states in KeyContext

### DIFF
--- a/src/keyszer/input.py
+++ b/src/keyszer/input.py
@@ -112,7 +112,7 @@ def receive_input(device):
                 if action.just_pressed():
                     dump_diagnostics()
 
-        on_event(event, device.name, device)
+        on_event(event, device)
 
 
 _add_timer = None

--- a/src/keyszer/input.py
+++ b/src/keyszer/input.py
@@ -112,7 +112,7 @@ def receive_input(device):
                 if action.just_pressed():
                     dump_diagnostics()
 
-        on_event(event, device.name)
+        on_event(event, device.name, device)
 
 
 _add_timer = None

--- a/src/keyszer/lib/key_context.py
+++ b/src/keyszer/lib/key_context.py
@@ -28,7 +28,7 @@ class KeyContext:
 
     @property
     def device_name(self):
-        return self.device.name
+        return self._device.name
 
     @property
     def capslock_on(self):

--- a/src/keyszer/lib/key_context.py
+++ b/src/keyszer/lib/key_context.py
@@ -6,6 +6,24 @@ class KeyContext:
         self._device_name = device_name
         self._X_ctx = None
 
+        # Must declare these here or app will crash if keyboard device hasn't been "grabbed" yet
+        self._capslock_state = ""
+        self._numlock_state = ""
+
+        leds_list = []
+
+        # Check for actual device name being present before using evdev's ".leds()" method
+        if not device == "":
+            leds_list = device.leds()
+            if 1 in leds_list:
+                self._capslock_state = "ON"
+            else:
+                self._capslock_state = "OFF"
+            if 0 in leds_list:
+                self._numlock_state = "ON"
+            else:
+                self._numlock_state = "OFF"
+
     def _query_window_context(self):
         # cache this,  think it might be expensive
         if self._X_ctx is None:
@@ -29,3 +47,11 @@ class KeyContext:
     @property
     def device_name(self):
         return self._device_name
+
+    @property
+    def capslock_state(self):
+        return self._capslock_state
+
+    @property
+    def numlock_state(self):
+        return self._numlock_state

--- a/src/keyszer/lib/key_context.py
+++ b/src/keyszer/lib/key_context.py
@@ -2,27 +2,21 @@ from ..xorg import get_xorg_context
 
 
 class KeyContext:
-    def __init__(self, device_name, device):
-        self._device_name = device_name
+    def __init__(self, device):
         self._X_ctx = None
+        leds_list = []
 
         # Must declare these here or app will crash if keyboard device hasn't been "grabbed" yet
         self._capslock_state = ""
         self._numlock_state = ""
 
-        leds_list = []
-
         # Check for actual device name being present before using evdev's ".leds()" method
+        # or device.name (doesn't like strings)
         if not device == "":
+            self._device_name = device.name
             leds_list = device.leds()
-            if 1 in leds_list:
-                self._capslock_state = "ON"
-            else:
-                self._capslock_state = "OFF"
-            if 0 in leds_list:
-                self._numlock_state = "ON"
-            else:
-                self._numlock_state = "OFF"
+            self._capslock_state = "ON" if 1 in leds_list else "OFF"
+            self._numlock_state = "ON" if 0 in leds_list else "OFF"
 
     def _query_window_context(self):
         # cache this,  think it might be expensive

--- a/src/keyszer/lib/key_context.py
+++ b/src/keyszer/lib/key_context.py
@@ -4,7 +4,7 @@ from ..xorg import get_xorg_context
 class KeyContext:
     def __init__(self, device):
         self._X_ctx = None
-        self.device = device
+        self._device = device
 
     def _query_window_context(self):
         # cache this,  think it might be expensive
@@ -33,9 +33,9 @@ class KeyContext:
     @property
     def capslock_on(self):
         CL_LED = 1  # evdev puts int 1 in leds() list if Capslock is ON
-        return True if CL_LED in self.device.leds() else False
+        return True if CL_LED in self._device.leds() else False
 
     @property
     def numlock_on(self):
         NL_LED = 0  # evdev puts int 0 in leds() list if Numlock is ON
-        return True if NL_LED in self.device.leds() else False
+        return True if NL_LED in self._device.leds() else False

--- a/src/keyszer/lib/key_context.py
+++ b/src/keyszer/lib/key_context.py
@@ -28,8 +28,7 @@ class KeyContext:
 
     @property
     def device_name(self):
-        self._device_name = self.device.name
-        return self._device_name
+        return self.device.name
 
     @property
     def capslock_on(self):

--- a/src/keyszer/lib/key_context.py
+++ b/src/keyszer/lib/key_context.py
@@ -4,19 +4,7 @@ from ..xorg import get_xorg_context
 class KeyContext:
     def __init__(self, device):
         self._X_ctx = None
-        leds_list = []
-
-        # Must declare these here or app will crash if keyboard device hasn't been "grabbed" yet
-        self._capslock_state = ""
-        self._numlock_state = ""
-
-        # Check for actual device name being present before using evdev's ".leds()" method
-        # or device.name (doesn't like strings)
-        if not device == "":
-            self._device_name = device.name
-            leds_list = device.leds()
-            self._capslock_state = "ON" if 1 in leds_list else "OFF"
-            self._numlock_state = "ON" if 0 in leds_list else "OFF"
+        self.device = device
 
     def _query_window_context(self):
         # cache this,  think it might be expensive
@@ -40,12 +28,15 @@ class KeyContext:
 
     @property
     def device_name(self):
+        self._device_name = self.device.name
         return self._device_name
 
     @property
-    def capslock_state(self):
-        return self._capslock_state
+    def capslock_on(self):
+        self._capslock_on = True if 1 in self.device.leds() else False
+        return self._capslock_on
 
     @property
-    def numlock_state(self):
-        return self._numlock_state
+    def numlock_on(self):
+        self._numlock_on = True if 0 in self.device.leds() else False
+        return self._numlock_on

--- a/src/keyszer/lib/key_context.py
+++ b/src/keyszer/lib/key_context.py
@@ -33,10 +33,8 @@ class KeyContext:
 
     @property
     def capslock_on(self):
-        self._capslock_on = True if 1 in self.device.leds() else False
-        return self._capslock_on
+        return True if 1 in self.device.leds() else False
 
     @property
     def numlock_on(self):
-        self._numlock_on = True if 0 in self.device.leds() else False
-        return self._numlock_on
+        return True if 0 in self.device.leds() else False

--- a/src/keyszer/lib/key_context.py
+++ b/src/keyszer/lib/key_context.py
@@ -32,10 +32,10 @@ class KeyContext:
 
     @property
     def capslock_on(self):
-        CL_LED = 1          # evdev puts int 1 in leds() list if Capslock is ON
+        CL_LED = 1  # evdev puts int 1 in leds() list if Capslock is ON
         return True if CL_LED in self.device.leds() else False
 
     @property
     def numlock_on(self):
-        NL_LED = 0          # evdev puts int 0 in leds() list if Numlock is ON
+        NL_LED = 0  # evdev puts int 0 in leds() list if Numlock is ON
         return True if NL_LED in self.device.leds() else False

--- a/src/keyszer/lib/key_context.py
+++ b/src/keyszer/lib/key_context.py
@@ -2,7 +2,7 @@ from ..xorg import get_xorg_context
 
 
 class KeyContext:
-    def __init__(self, device_name):
+    def __init__(self, device_name, device):
         self._device_name = device_name
         self._X_ctx = None
 

--- a/src/keyszer/lib/key_context.py
+++ b/src/keyszer/lib/key_context.py
@@ -32,8 +32,10 @@ class KeyContext:
 
     @property
     def capslock_on(self):
-        return True if 1 in self.device.leds() else False
+        CL_LED = 1          # evdev puts int 1 in leds() list if Capslock is ON
+        return True if CL_LED in self.device.leds() else False
 
     @property
     def numlock_on(self):
-        return True if 0 in self.device.leds() else False
+        NL_LED = 0          # evdev puts int 0 in leds() list if Numlock is ON
+        return True if NL_LED in self.device.leds() else False

--- a/src/keyszer/lib/key_context.py
+++ b/src/keyszer/lib/key_context.py
@@ -1,4 +1,5 @@
 from ..xorg import get_xorg_context
+from ..models.key import Key
 
 
 class KeyContext:
@@ -32,10 +33,8 @@ class KeyContext:
 
     @property
     def capslock_on(self):
-        CL_LED = 1  # evdev puts int 1 in leds() list if Capslock is ON
-        return True if CL_LED in self._device.leds() else False
+        return Key.LED_CAPSL in self._device.leds()
 
     @property
     def numlock_on(self):
-        NL_LED = 0  # evdev puts int 0 in leds() list if Numlock is ON
-        return True if NL_LED in self._device.leds() else False
+        return Key.LED_NUML in self._device.leds()

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -293,13 +293,13 @@ def find_keystate_or_new(inkey, action):
 
 
 # @benchit
-def on_event(event, device_name, device=""):
+def on_event(event, device):
     # we do not attempt to transform non-key events
     if event.type != ecodes.EV_KEY:
         _output.send_event(event)
         return
 
-    context = KeyContext(device_name, device)
+    context = KeyContext(device)
     action = Action(event.value)
     key = Key(event.code)
 

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -293,13 +293,13 @@ def find_keystate_or_new(inkey, action):
 
 
 # @benchit
-def on_event(event, device_name):
+def on_event(event, device_name, device=""):
     # we do not attempt to transform non-key events
     if event.type != ecodes.EV_KEY:
         _output.send_event(event)
         return
 
-    context = KeyContext(device_name)
+    context = KeyContext(device_name, device)
     action = Action(event.value)
     key = Key(event.code)
 

--- a/tests/lib/api.py
+++ b/tests/lib/api.py
@@ -5,12 +5,15 @@ from lib.xorg_mock import set_window
 from keyszer.models.action import PRESS, RELEASE
 from keyszer.transform import on_event
 
-_kb = "generic keyboard"
+class MockKeyboard:
+    name = "generic keyboard"
 
+
+_kb = MockKeyboard()
 
 def using_keyboard(name):
     global _kb
-    _kb = name
+    _kb.name = name
 
 
 def window(name):


### PR DESCRIPTION
Draft changes to resolve issue #24. 

Adds `capslock_state` and `numlock_state` properties to `KeyContext`. 

Could not discover how to get `device.name` to work inside `KeyContext`, so I stuck with just passing in the full device as an optional parameter to `on_event`. 

I've had confusing issues trying to return booleans, so I changed it to returning strings of `ON` or `OFF` for each lock key's states. 

Issues: 

* If either lock key is enabled when the app starts running, it will be out of sync with what `keyszer` thinks the lock states are (OFF), until that lock key is cycled from one state to another. Then everything should remain synced. 
* There is no device or device name present until at least one key is pressed, so initial states of the lock key properties are indeterminate. Variables are initialized as empty strings to avoid a crash prior to the keyboard device being grabbed. 

The state of the code in this PR is working for me with this test code block in my Kinto config file: 

```python
ST = to_US_keystrokes

keymap("Test of capslock_state", {
    C("KPDot"): ST("KPDot with capslock_state == 'ON'"),
}, when = lambda ctx: ctx.wm_class not in remotes and ctx.capslock_state == "ON")

keymap("Test of numlock_state", {
    C("KP5"): ST("KP5 with numlock_state == 'OFF'"),
}, when = lambda ctx: ctx.wm_class not in remotes and ctx.numlock_state == "OFF")
```

Test with this in any text editor, and it should output the designated descriptive strings, respectively, when Capslock is "ON" and Numlock is "OFF". You'll have to pick different input keys if you don't have a Numpad available. 

Of course, with the Capslock key engaged, the output of the string processor gets inverted for normal letters. This is expected. Perhaps being able to access the Capslock state will allow the string processor to be modified so that it always outputs letters as if the Capslock state was "OFF". 
