### PR TITLE
Flush all printed log output to reduce buffering

### DIFF
--- a/src/keyszer/lib/logger.py
+++ b/src/keyszer/lib/logger.py
@@ -7,21 +7,21 @@ def debug(*args, ctx="DD"):
 
     # allow blank lines without context
     if len(args) == 0 or (len(args) == 1 and args[0] == ""):
-        print("")
+        print("", flush=True)
         return
-    print(f"({ctx})", *args)
+    print(f"({ctx})", *args, flush=True)
 
 
 def warn(*args, ctx="WW"):
-    print(f"({ctx})", *args)
+    print(f"({ctx})", *args, flush=True)
 
 
 def error(*args, ctx="EE"):
-    print(f"({ctx})", *args)
+    print(f"({ctx})", *args, flush=True)
 
 
 def log(*args, ctx="--"):
-    print(f"({ctx})", *args)
+    print(f"({ctx})", *args, flush=True)
 
 
 def info(*args, ctx="--"):


### PR DESCRIPTION
Some terminals buffer significant amounts of log output and make it difficult to troubleshoot by watching logging info in the terminal. 

Adding "flush=True" to all print commands in the logger should solve this issue, at least for built-in logging output.

Related: Issue #58
