### PR TITLE
(enh) Add log output flushing with `--flush`

### DIFF
--- a/src/keyszer/cli.py
+++ b/src/keyszer/cli.py
@@ -105,6 +105,9 @@ def main():
         "-v", dest="verbose", action="store_true", help="increase debug logging"
     )
     parser.add_argument(
+        "--flush", dest="flush", action="store_true", help="flush log output to reduce terminal buffering"
+    )
+    parser.add_argument(
         "--list-devices", dest="list_devices", action="store_true", help=""
     )
     parser.add_argument(
@@ -130,6 +133,9 @@ def main():
 
     if args.verbose:
         logger.VERBOSE = True
+
+    if args.flush:
+        logger.FLUSH = True
 
     print(f"{__name__} v{__version__}")
 

--- a/src/keyszer/cli.py
+++ b/src/keyszer/cli.py
@@ -105,7 +105,7 @@ def main():
         "-v", dest="verbose", action="store_true", help="increase debug logging"
     )
     parser.add_argument(
-        "--flush", dest="flush", action="store_true", help="flush log output to reduce terminal buffering"
+        "--flush", dest="flush", action="store_true", help="immediately flush all log output"
     )
     parser.add_argument(
         "--list-devices", dest="list_devices", action="store_true", help=""

--- a/src/keyszer/lib/logger.py
+++ b/src/keyszer/lib/logger.py
@@ -1,5 +1,5 @@
 VERBOSE = False
-
+FLUSH = False
 
 def debug(*args, ctx="DD"):
     if not VERBOSE:
@@ -7,21 +7,21 @@ def debug(*args, ctx="DD"):
 
     # allow blank lines without context
     if len(args) == 0 or (len(args) == 1 and args[0] == ""):
-        print("", flush=True)
+        print("", flush=FLUSH)
         return
-    print(f"({ctx})", *args, flush=True)
+    print(f"({ctx})", *args, flush=FLUSH)
 
 
 def warn(*args, ctx="WW"):
-    print(f"({ctx})", *args, flush=True)
+    print(f"({ctx})", *args, flush=FLUSH)
 
 
 def error(*args, ctx="EE"):
-    print(f"({ctx})", *args, flush=True)
+    print(f"({ctx})", *args, flush=FLUSH)
 
 
 def log(*args, ctx="--"):
-    print(f"({ctx})", *args, flush=True)
+    print(f"({ctx})", *args, flush=FLUSH)
 
 
 def info(*args, ctx="--"):

--- a/src/keyszer/lib/logger.py
+++ b/src/keyszer/lib/logger.py
@@ -7,21 +7,21 @@ def debug(*args, ctx="DD"):
 
     # allow blank lines without context
     if len(args) == 0 or (len(args) == 1 and args[0] == ""):
-        print("")
+        print("", flush=True)
         return
-    print(f"({ctx})", *args)
+    print(f"({ctx})", *args, flush=True)
 
 
 def warn(*args, ctx="WW"):
-    print(f"({ctx})", *args)
+    print(f"({ctx})", *args, flush=True)
 
 
 def error(*args, ctx="EE"):
-    print(f"({ctx})", *args)
+    print(f"({ctx})", *args, flush=True)
 
 
 def log(*args, ctx="--"):
-    print(f"({ctx})", *args)
+    print(f"({ctx})", *args, flush=True)
 
 
 def info(*args, ctx="--"):


### PR DESCRIPTION
Adds CLI argument "--flush" to enable continuous flushing of any log output to reduce the occurrence of excessive buffering that may happen in some terminals. 

Default state of the FLUSH constant defined in the logger is False, so the value of the trailing `print` arguments will be "flush=False" unless the "--flush" CLI argument is used to enable the feature. 

This is working for me. 

Renaming my branch before adding the second file automatically closed the other PR for this. 
