### PR TITLE
(enh) Trigger.IMMEDIATELY

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,18 @@ keymap("multi stroke", {
 })
 ```
 
+If you'd like the first keystroke to also produce it's own output, `immediately` can be used:
+
+```python
+keymap("multi stroke", {
+  C("C-x"): {
+    # immediately output "x" when Ctrl-X is pressed
+    immediately: C("x"),
+    C("C-c"): C("C-q"),
+  }
+})
+```
+
 #### Finding out the proper `Key.NAME` literal for a key on your keyboard
 
 From a terminal session run `evtest` and select your keyboard's input device.  Now hit the key in question.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Keyszer works at quite a low-level.  It grabs input directly from the kernel's [
   - configurable `EMERGENCY EJECT` hotkey
   - configurable `DIAGNOSTIC` hotkey
 - fully supports running as semi-privileged user (using `root` is now deprecated)
+- adds `immediately` to nested keymaps
 - adds `Meta`, `Command` and `Cmd` aliases for Super/Meta modifier
 - add `C` combo helper (eventually to replace `K`)
 - supports custom modifiers via `add_modifier` (such as `Hyper`)

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -8,6 +8,7 @@ from inspect import signature
 from .lib.logger import error
 from .models.action import Action
 from .models.combo import Combo, ComboHint
+from .models.trigger import Trigger
 from .models.key import Key, ASCII_TO_KEY
 from .models.keymap import Keymap
 from .models.modifier import Modifier
@@ -17,6 +18,8 @@ from .models.modmap import Modmap, MultiModmap
 bind = ComboHint.BIND
 escape_next_key = ComboHint.ESCAPE_NEXT
 ignore_key = ComboHint.IGNORE
+
+immediately = Trigger.IMMEDIATELY
 
 # keycode translation
 # e.g., { Key.CAPSLOCK: Key.LEFT_CTRL }

--- a/src/keyszer/models/trigger.py
+++ b/src/keyszer/models/trigger.py
@@ -1,0 +1,7 @@
+from enum import IntEnum, unique
+
+
+@unique
+class Trigger(IntEnum):
+    IMMEDIATELY = 1
+

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -9,6 +9,7 @@ from .lib.key_context import KeyContext
 from .lib.logger import debug
 from .models.action import Action
 from .models.combo import Combo, ComboHint
+from .models.trigger import Trigger
 from .models.key import Key
 from .models.keymap import Keymap
 from .models.keystate import Keystate
@@ -561,7 +562,10 @@ def handle_commands(commands, key, action, input_combo=None):
                 return True
             # Go to next keymap
             elif isinstance(command, Keymap):
-                _active_keymaps = [command]
+                keymap = command
+                if Trigger.IMMEDIATELY in keymap:
+                    handle_commands(keymap[Trigger.IMMEDIATELY], None, None)
+                _active_keymaps = [keymap]
                 return False
             # to_keystrokes and unicode_keystrokes produce lists so
             # we'll just handle it recursively

--- a/tests/test_nested_keymaps.py
+++ b/tests/test_nested_keymaps.py
@@ -68,3 +68,32 @@ async def test_nested_keymaps():
         (RELEASE, Key.KEY_9),
         (RELEASE, Key.LEFT_ALT),
     ]
+
+
+async def test_trigger_immediately():
+    keymap("Firefox",{
+        K("C-a"): {
+            immediately: K("8"),
+            K("C-b"): K("Alt-KEY_9")
+        }
+    })
+
+    boot_config()
+
+    press(Key.LEFT_CTRL)
+    press(Key.A)
+    release(Key.A)
+    press(Key.B)
+    release(Key.B)
+    release(Key.LEFT_CTRL)
+
+    # the 8 (as the immediate effect of the C-a combo) is pressed
+    # first, and without any modifiers
+    assert _out.keys() == [
+        (PRESS, Key.KEY_8),
+        (RELEASE, Key.KEY_8),
+        (PRESS, Key.LEFT_ALT),
+        (PRESS, Key.KEY_9),
+        (RELEASE, Key.KEY_9),
+        (RELEASE, Key.LEFT_ALT),
+    ]


### PR DESCRIPTION
<!--- Provide a quick summary of your changes in the Title above -->

### Changes

Adds an immediate trigger to nested keymaps that applies as soon as the keymap is triggered.

```py
    keymap("Firefox",{
        K("C-a"): {
            immediately: K("8"),
            K("C-b"): K("Alt-KEY_9")
        }
    })
```

So now keymaps can have an immediate effect _in addition to_ switching the keymap.

<!-- `Resolves #12345`, etc. Then describe your changes... -->

**Checklist**

- [x] Added tests (if necessary)
- [ ] Updated docs or README...
