### PR TITLE
(enh) allow multiple conditional modmaps to apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ The negation of `wm_class_match`, matches only when the regex does NOT match.
 
 ### `modmap(name, mappings, when_conditional = None)`
 
-Maps a single physical key to a different key.  A default modmap will always be overruled by any conditional modmaps that apply.  `when_conditional` can be passed to make the modmap conditional.
+Maps a single physical key to a different key.  A default modmap will always be overruled by any conditional modmaps that apply.  `when_conditional` can be passed to make the modmap conditional.  The first modmap found that includes the pressed key and matches the `when_conditional` will be used to remap the key.
 
 ```py
 modmap("default", {
@@ -331,7 +331,7 @@ modmap("default", {
 })
 ```
 
-If you don't create a default (non-conditional) modmap a blank one is created for you.  For `modmap` sides of the pairing will be `Key` literals (not combos).
+If you don't create a default (non-conditional) modmap a blank one is created for you.  For `modmap` both sides of the pairing will be `Key` literals (not combos).
 
 
 ### `multipurpose_modmap(name, mappings)`

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -234,9 +234,10 @@ def apply_modmap(keystate, context):
     # debug("conditionals", conditional_modmaps)
     if conditional_modmaps:
         for modmap in conditional_modmaps:
-            if modmap.conditional(context):
-                active_modmap = modmap
-                break
+            if inkey in modmap:
+                if modmap.conditional(context):
+                    active_modmap = modmap
+                    break
     if active_modmap and inkey in active_modmap:
         debug(f"modmap: {inkey} => {active_modmap[inkey]} [{active_modmap.name}]")
         keystate.key = active_modmap[inkey]
@@ -247,9 +248,10 @@ def apply_multi_modmap(keystate, context):
     conditional_multimaps = _MULTI_MODMAPS[1:]
     if conditional_multimaps:
         for modmap in conditional_multimaps:
-            if modmap.conditional(context):
-                active_multi_modmap = modmap
-                break
+            if keystate.inkey in modmap:
+                if modmap.conditional(context):
+                    active_multi_modmap = modmap
+                    break
 
     if active_multi_modmap:
         if keystate.key in active_multi_modmap:

--- a/tests/test_modmap_cond.py
+++ b/tests/test_modmap_cond.py
@@ -108,6 +108,45 @@ async def test_when_in_emacs():
         (RELEASE, Key.ESC),
     ]
 
+
+async def test_multiple_conditional_maps_can_match():
+    define_conditional_modmap(re.compile(r'Chrome'), {
+        Key.RIGHT_CTRL: Key.ESC,
+    })
+
+    define_conditional_modmap(re.compile(r'Chrome'), {
+        Key.LEFT_CTRL: Key.ESC,
+    })
+
+    boot_config()
+
+    window("Google Chrome")
+
+    press(Key.RIGHT_CTRL)
+    press(Key.F)
+    release(Key.F)
+    release(Key.RIGHT_CTRL)
+
+    press(Key.LEFT_CTRL)
+    press(Key.G)
+    release(Key.G)
+    release(Key.LEFT_CTRL)
+
+
+
+    assert _out.keys() == [
+        # first modmap
+        (PRESS, Key.ESC),
+        (PRESS, Key.F),
+        (RELEASE, Key.F),
+        (RELEASE, Key.ESC),
+        # falls to second modmap
+        (PRESS, Key.ESC),
+        (PRESS, Key.G),
+        (RELEASE, Key.G),
+        (RELEASE, Key.ESC),
+    ]
+
 @pytest.mark.skip
 async def test_sticky_switch_modmaps_midstream():
     # TODO: correct behavior?


### PR DESCRIPTION
Resolves #86.

When searching for a conditional modmap we now also check to see
if the key pressed actually exists inside that modmap... so if
multiple modmaps match the conditional they will all be "evaluated"
until one is found that matches the key pressed.

If two conditional modmaps both match the current state and both
include the pressed key then the first one (in order of definition)
wins.  It is recommended that typically your modmaps should not
overlap like this.

<!--- Provide a quick summary of your changes in the Title above -->

### Changes

<!-- Reference a related issue (if one exists) so things are linked nicely: -->

<!-- `Resolves #12345`, etc. Then describe your changes... -->

**Checklist**

- [x] Added tests (if necessary)
- [ ] Updated docs or README...
