### PR TITLE
multi repeat broken

### DIFF
--- a/src/keyszer/models/action.py
+++ b/src/keyszer/models/action.py
@@ -15,9 +15,14 @@ class Action(IntEnum):
     def is_released(self):
         return self == Action.RELEASE
 
+    @property
+    def is_repeat(self):
+        return self == Action.REPEAT
+
     def __str__(self):
         return self.name.lower()
 
 
 PRESS = Action.PRESS
 RELEASE = Action.RELEASE
+REPEAT = Action.REPEAT

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -386,6 +386,10 @@ def on_key(keystate, context):
         update_pressed_states(keystate)
         suspend_keys(_TIMEOUTS["multipurpose"])
 
+    elif keystate.is_multi and action.is_repeat and keystate.suspended:
+        pass
+        # do nothing
+
     # regular key releases, not modifiers (though possibly a multi-mod)
     elif action.is_released():
         if _output.is_pressed(key):

--- a/src/keyszer/version.py
+++ b/src/keyszer/version.py
@@ -1,6 +1,6 @@
 __name__ = "keyszer"
 
-__version__ = "0.6.91"
+__version__ = "0.6.92"
 
 __description__ = "A smart, flexible key remapper for Linux/X11."
 

--- a/tests/lib/api.py
+++ b/tests/lib/api.py
@@ -2,7 +2,7 @@ from evdev.ecodes import EV_KEY
 from evdev.events import InputEvent
 from lib.xorg_mock import set_window
 
-from keyszer.models.action import PRESS, RELEASE
+from keyszer.models.action import PRESS, RELEASE, REPEAT
 from keyszer.transform import on_event
 
 class MockKeyboard:
@@ -27,6 +27,10 @@ def press(key):
 
 def release(key):
     ev = InputEvent(0, 0, EV_KEY, key, RELEASE)
+    on_event(ev, _kb)
+
+def repeat(key):
+    ev = InputEvent(0, 0, EV_KEY, key, REPEAT)
     on_event(ev, _kb)
 
 

--- a/tests/test_modmap_multi.py
+++ b/tests/test_modmap_multi.py
@@ -4,7 +4,7 @@ import warnings
 
 import pytest
 import pytest_asyncio
-from lib.api import PRESS, RELEASE, hit, press, release
+from lib.api import PRESS, RELEASE, hit, press, release, repeat
 from lib.uinput_stub import UInputStub
 
 from keyszer.config_api import modmap, multipurpose_modmap, reset_configuration
@@ -132,5 +132,28 @@ async def test_shift_multi_modifier():
         (PRESS, Key.RIGHT_SHIFT),
         (PRESS, Key.BACKSLASH),
         (RELEASE, Key.RIGHT_SHIFT),
+        (RELEASE, Key.BACKSLASH),
+    ]
+
+
+@pytest.mark.looptime
+async def test_hold_multi_normal_by_itself():
+
+    multipurpose_modmap(
+        "default",
+        # Enter is enter when pressed and released. Control when held down.
+        {Key.BACKSLASH: [Key.BACKSLASH, Key.RIGHT_CTRL]}
+    )
+
+    boot_config()
+
+    press(Key.BACKSLASH)
+    repeat(Key.BACKSLASH)
+    repeat(Key.BACKSLASH)
+    repeat(Key.BACKSLASH)
+    release(Key.BACKSLASH)
+
+    assert _out.keys() == [
+        (PRESS, Key.BACKSLASH),
         (RELEASE, Key.BACKSLASH),
     ]

--- a/tests/test_modmap_multi.py
+++ b/tests/test_modmap_multi.py
@@ -141,7 +141,6 @@ async def test_hold_multi_normal_by_itself():
 
     multipurpose_modmap(
         "default",
-        # Enter is enter when pressed and released. Control when held down.
         {Key.BACKSLASH: [Key.BACKSLASH, Key.RIGHT_CTRL]}
     )
 
@@ -155,5 +154,6 @@ async def test_hold_multi_normal_by_itself():
 
     assert _out.keys() == [
         (PRESS, Key.BACKSLASH),
+        # repeats are dropped because key is suspended
         (RELEASE, Key.BACKSLASH),
     ]


### PR DESCRIPTION
Should resolve #93.

### Changes

If one holds down BACKSLASH the first repeat event is
treated as almost a different key and will trigger that
repeat event to fire (for the actual backspae key) but
also cause the modifier key to be output as well.

When all is said and done since the repeat output was
a glitch it will remain "incorrectly" held on the output.

This adds an extra check for suspended multi-keys that
are getting repeat events and silently drops them, as
they are not needed - they key will be "woke" either
when the multi-timer expires or when the key is released.

**Checklist**

- [x] Added tests (if necessary)
- [x] Updated docs or README... (not needed)
