### PR TITLE
Fixes #95 w/ .012s output delay

### DIFF
--- a/src/keyszer/output.py
+++ b/src/keyszer/output.py
@@ -1,3 +1,4 @@
+import time
 from evdev import ecodes
 from evdev.uinput import UInput
 
@@ -99,6 +100,7 @@ class Output:
     def send_key_action(self, key, action):
         self.__update_pressed_modifier_keys(key, action)
         self.__update_pressed_keys(key, action)
+        time.sleep(.012)
         _uinput.write(ecodes.EV_KEY, key, action)
         debug(action, key, ctx="OO")
         self.__send_sync()


### PR DESCRIPTION
This change introduces a .012 second delay to all hotkey transformations. May be related to xkb/xinput stack that could impact various DE's or just impacts Budgie specifically. Whether this value will need to be increased for other DE's is unknown as it has only been tested against Budgie at this time (Ubunut Budgie 22.04).

### Changes

Resolves #95 and changes output.py to include the delay needed.

**Checklist**

- [ ? ] Added tests (if necessary)
- [ ? ] Updated docs or README...
