### PR TITLE
(enh) adds `include` support for config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Keyszer works at quite a low-level.  It grabs input directly from the kernel's [
   - configurable `EMERGENCY EJECT` hotkey
   - configurable `DIAGNOSTIC` hotkey
 - fully supports running as semi-privileged user (using `root` is now deprecated)
+- adds `include` to allow config to pull in other Python files
 - adds `immediately` to nested keymaps
 - adds `Meta`, `Command` and `Cmd` aliases for Super/Meta modifier
 - add `C` combo helper (eventually to replace `K`)
@@ -257,7 +258,17 @@ The configuration API:
 - `conditional(condition_fn, map)` - used to wrap maps, applying them conditionally
 - `dump_diagnostics_key(key)`
 - `emergency_eject_key(key)`
+- `include(relative_filename)`
 
+### `include(relative_filename)`
+
+Include a sub-configuration file into the existing config.  This file is loaded and executed at the point of inclusion and shares the same global scope as the existing config. These files should be present in the same directory as your main configuration.
+
+```py
+include("os.py")
+include("apps.py")
+include("deadkeys.py")
+```
 
 ### `timeouts(...)`
 

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -3,6 +3,8 @@ import re
 import string
 import sys
 import time
+import os
+import inspect
 from inspect import signature
 
 from .lib.logger import error
@@ -295,6 +297,15 @@ def with_or_set_mark(combo):
 
 
 # ─── STANDARD API ───────────────────────────────────────────────────────────
+
+
+def include(file):
+    dirname = os.path.dirname(file)
+    name = f"{dirname}{file}"
+    with open(name, "rb") as file:
+        code = file.read()
+        config_globals = inspect.stack()[1][0].f_globals
+    exec(compile(code, name, "exec"), config_globals)  # nosec
 
 
 def timeouts(multipurpose=1, suspend=1):

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -300,11 +300,11 @@ def with_or_set_mark(combo):
 
 
 def include(file):
-    dirname = os.path.dirname(file)
-    name = f"{dirname}{file}"
+    config_globals = inspect.stack()[1][0].f_globals
+    dirname = os.path.dirname(config_globals["__config__"])
+    name = os.path.join(dirname, file)
     with open(name, "rb") as file:
         code = file.read()
-        config_globals = inspect.stack()[1][0].f_globals
     exec(compile(code, name, "exec"), config_globals)  # nosec
 
 

--- a/src/keyszer/output.py
+++ b/src/keyszer/output.py
@@ -1,5 +1,7 @@
+import time
 from evdev import ecodes
 from evdev.uinput import UInput
+
 
 from .lib.logger import debug
 from .models.action import PRESS, RELEASE
@@ -100,7 +102,7 @@ class Output:
         self.__update_pressed_modifier_keys(key, action)
         self.__update_pressed_keys(key, action)
         _uinput.write(ecodes.EV_KEY, key, action)
-        debug(action, key, ctx="OO")
+        debug(action, key, time.time(), ctx="OO")
         self.__send_sync()
 
     def send_combo(self, combo):


### PR DESCRIPTION
Resolves #30.

### Changes

### `include(relative_filename)`

Include a sub-configuration file into the existing config.  This file is loaded and executed at the point of inclusion and shares the same global scope as the existing config. These files should be present in the same directory as your main configuration.

```py
include("os.py")
include("apps.py")
include("deadkeys.py")
```

**Checklist**

- [ ] Added tests (if necessary)
- [x] Updated docs or README...
