### PR TITLE
Fix for WM_NAME(COMPOUND_TEXT) issue

### DIFF
--- a/src/keyszer/xorg.py
+++ b/src/keyszer/xorg.py
@@ -31,11 +31,8 @@ def get_xorg_context():
         input_focus = _display.get_input_focus().focus
         window = get_actual_window(input_focus)
         if window:
-            wm_name = window.get_wm_name()
-            # Sometimes legacy WM_NAME attribute is encoded as COMPOUND_TEXT,
-            # causing empty byte object to return, instead of string. To fix:
-            if isinstance(wm_name, bytes) or len(wm_name) == 0:
-                wm_name = window.get_full_text_property(343)    # use _NET_WM_NAME string instead
+            # use _NET_WM_NAME string instead of WM_NAME to bypass (COMPOUND_TEXT) encoding problems
+            wm_name = window.get_full_text_property(_display.get_atom("_NET_WM_NAME"))
             pair = window.get_wm_class()
             if pair:
                 wm_class = str(pair[1])

--- a/src/keyszer/xorg.py
+++ b/src/keyszer/xorg.py
@@ -32,6 +32,10 @@ def get_xorg_context():
         window = get_actual_window(input_focus)
         if window:
             wm_name = window.get_wm_name()
+            # Sometimes legacy WM_NAME attribute is encoded as COMPOUND_TEXT,
+            # causing empty byte object to return, instead of string. To fix:
+            if isinstance(wm_name, bytes) or len(wm_name) == 0:
+                wm_name = window.get_full_text_property(343)    # use _NET_WM_NAME string instead
             pair = window.get_wm_class()
             if pair:
                 wm_class = str(pair[1])


### PR DESCRIPTION
As outlined in issue #104, sometimes the "legacy" WM_NAME window attribute returns a result encoded as (COMPOUND_TEXT), which results in `window.get_wm_name()` returning an empty "bytes" object rather than the correct window title string. 

An alternate attribute called _NET_WM_NAME provides the same window title, but in UTF-8 string format that will work properly with regex matching. 

Should resolve issue #104.

<!--- Provide a quick summary of your changes in the Title above -->

### Changes

<!-- Reference a related issue (if one exists) so things are linked nicely: -->

<!-- `Resolves #12345`, etc. Then describe your changes... -->

**Checklist**

- [ ] Added tests (if necessary)
- [ ] Updated docs or README...
