### PR TITLE
Logging improvement

### DIFF
--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -445,7 +445,7 @@ def transform_key(key, action, ctx):
 
         if logger.VERBOSE:
             keymap_names = [map.name for map in _active_keymaps]
-            name_list = ", ".join(keymap_names)
+            # name_list = ", ".join(keymap_names)
             debug("")
             debug(
                 f"WM_CLS = '{ctx.wm_class}' | "
@@ -454,10 +454,17 @@ def transform_key(key, action, ctx):
                 f"DVN = '{ctx.device_name}' | "
                 f"CLK = '{ctx.capslock_on}' | "
                 f"NLK = '{ctx.numlock_on}'")
-            debug(f"Active Keymaps = ")
+            n = 1
             for km_name in keymap_names:
-                debug(f" KMAP: [{km_name}]")
-            debug(f"  COMBO: {combo} => {keymap[combo]} [{keymap.name}]")
+                if n == 1: print(f"(DD) KMAPS = [{km_name}, ", end='')
+                elif n % 2 != 0 and n < len(keymap_names):
+                    print(f"(DD)          {km_name}, ", end='')
+                elif n % 2 != 0 and n == len(keymap_names):
+                    print(f"(DD)          {km_name}]")
+                elif n == len(keymap_names): print(f"{km_name}]")
+                else: print(f"{km_name},")
+                n+=1
+            debug(f"COMBO: {combo} => {keymap[combo]} [{keymap.name}]")
 
         held = get_pressed_states()
         for ks in held:

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -448,16 +448,16 @@ def transform_key(key, action, ctx):
             # name_list = ", ".join(keymap_names)
             debug("")
             debug(
-                f"WM_CLS = '{ctx.wm_class}' | "
-                f"WM_NME = '{ctx.wm_name}'")
+                f"WM_CLS: '{ctx.wm_class}' | "
+                f"WM_NME: '{ctx.wm_name}'")
             debug(
-                f"DVN = '{ctx.device_name}' | "
-                f"CLK = '{ctx.capslock_on}' | "
-                f"NLK = '{ctx.numlock_on}'")
+                f"DVN: '{ctx.device_name}' | "
+                f"CLK: '{ctx.capslock_on}' | "
+                f"NLK: '{ctx.numlock_on}'")
             n = 1
             for km_name in keymap_names:
-                if n == 1 and len(keymap_names) > 1: print(f"(DD) KMAPS = [{km_name}, ", end='')
-                elif n == 1 and len(keymap_names) == 1: print(f"(DD) KMAPS = [{km_name}]")
+                if n == 1 and len(keymap_names) > 1: print(f"(DD) KMAPS: [{km_name}, ", end='')
+                elif n == 1 and len(keymap_names) == 1: print(f"(DD) KMAPS: [{km_name}]")
                 elif n % 2 != 0 and n < len(keymap_names):
                     print(f"(DD)          {km_name}, ", end='')
                 elif n % 2 != 0 and n == len(keymap_names):
@@ -465,7 +465,7 @@ def transform_key(key, action, ctx):
                 elif n == len(keymap_names): print(f"{km_name}]")
                 else: print(f"{km_name},")
                 n+=1
-            debug(f"COMBO: {combo} => {keymap[combo]} [{keymap.name}]")
+            debug(f"COMBO: {combo} => {keymap[combo]} in KMAP: [{keymap.name}]")
 
         held = get_pressed_states()
         for ks in held:

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -216,6 +216,31 @@ def dump_diagnostics():
     print("")
 
 
+# ─── COMBO CONTEXT LOGGING ────────────────────────────────────────────────────────
+
+
+def log_combo_context(combo, ctx, keymap, _active_keymaps):
+    """Log context around usage of combo"""
+    import textwrap
+
+    debug("")
+    debug(f"WM_CLS: '{ctx.wm_class}' | WM_NME: '{ctx.wm_name}'")
+    debug(f"DVN: '{ctx.device_name}' | CLK: '{ctx.capslock_on}' | NLK: '{ctx.numlock_on}'")
+    debug(f'ACTIVE KEYMAPS:')
+
+    indent = ' ' * 5
+    max_len = max(80 - len(indent), 64)
+    wrapped_items = textwrap.wrap(", ".join([f"'{item.name}'" for item in _active_keymaps]), width=max_len)
+    output_str = f"{indent}{wrapped_items[0]}"
+    for item in wrapped_items[1:]:
+        if not item.startswith("'"):
+            item = ' ' + item
+        output_str += f"\n{indent}{item}"
+    print(output_str)
+
+    debug(f"COMBO: {combo} => {keymap[combo]} in KMAP: '{keymap.name}'")
+
+
 # ─── KEYBOARD INPUT PROCESSING HELPERS ──────────────────────────────────────────
 
 
@@ -444,31 +469,7 @@ def transform_key(key, action, ctx):
             continue
 
         if logger.VERBOSE:
-            keymap_names = [map.name for map in _active_keymaps]
-            # name_list = ", ".join(keymap_names)
-            debug("")
-            debug(
-                f"WM_CLS: '{ctx.wm_class}' | "
-                f"WM_NME: '{ctx.wm_name}'")
-            debug(
-                f"DVN: '{ctx.device_name}' | "
-                f"CLK: '{ctx.capslock_on}' | "
-                f"NLK: '{ctx.numlock_on}'")
-            prefix = "(DD) KMAPS:"
-            indent = " " * ( len(prefix) + 2 )
-            max_len = 80 - len(indent) - 2  # 2 is for quotes and comma
-            formatted_list = [f"'{keymap_names[0]}'"]
-            for name in keymap_names[1:]:
-                if len(formatted_list[-1]) + len(name) + 3 <= max_len:
-                    formatted_list[-1] += f", '{name}'"
-                else:
-                    formatted_list.append(f"'{name}'")
-            output_str = f"{prefix} [{formatted_list[0]}"
-            for line in formatted_list[1:]:
-                output_str += f",\n{indent}{line}"
-            output_str += "]"
-            print(output_str)
-            debug(f"COMBO: {combo} => {keymap[combo]} in KMAP: ['{keymap.name}']")
+            log_combo_context(combo, ctx, keymap, _active_keymaps)
 
         held = get_pressed_states()
         for ks in held:

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -459,9 +459,9 @@ def transform_key(key, action, ctx):
                 if n == 1 and len(keymap_names) > 1: print(f"(DD) KMAPS: ['{km_name}', ", end='')
                 elif n == 1 and len(keymap_names) == 1: print(f"(DD) KMAPS: ['{km_name}']")
                 elif n % 2 != 0 and n < len(keymap_names):
-                    print(f"(DD)         '{km_name}', ", end='')
+                    print(f"             '{km_name}', ", end='')
                 elif n % 2 != 0 and n == len(keymap_names):
-                    print(f"(DD)         '{km_name}']")
+                    print(f"             '{km_name}']")
                 elif n == len(keymap_names): print(f"'{km_name}']")
                 else: print(f"'{km_name}',")
                 n+=1

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -456,16 +456,16 @@ def transform_key(key, action, ctx):
                 f"NLK: '{ctx.numlock_on}'")
             n = 1
             for km_name in keymap_names:
-                if n == 1 and len(keymap_names) > 1: print(f"(DD) KMAPS: [{km_name}, ", end='')
-                elif n == 1 and len(keymap_names) == 1: print(f"(DD) KMAPS: [{km_name}]")
+                if n == 1 and len(keymap_names) > 1: print(f"(DD) KMAPS: ['{km_name}', ", end='')
+                elif n == 1 and len(keymap_names) == 1: print(f"(DD) KMAPS: ['{km_name}']")
                 elif n % 2 != 0 and n < len(keymap_names):
-                    print(f"(DD)         {km_name}, ", end='')
+                    print(f"(DD)         '{km_name}', ", end='')
                 elif n % 2 != 0 and n == len(keymap_names):
-                    print(f"(DD)         {km_name}]")
-                elif n == len(keymap_names): print(f"{km_name}]")
-                else: print(f"{km_name},")
+                    print(f"(DD)         '{km_name}']")
+                elif n == len(keymap_names): print(f"'{km_name}']")
+                else: print(f"'{km_name}',")
                 n+=1
-            debug(f"COMBO: {combo} => {keymap[combo]} in KMAP: [{keymap.name}]")
+            debug(f"COMBO: {combo} => {keymap[combo]} in KMAP: ['{keymap.name}']")
 
         held = get_pressed_states()
         for ks in held:

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -459,9 +459,9 @@ def transform_key(key, action, ctx):
                 if n == 1 and len(keymap_names) > 1: print(f"(DD) KMAPS: [{km_name}, ", end='')
                 elif n == 1 and len(keymap_names) == 1: print(f"(DD) KMAPS: [{km_name}]")
                 elif n % 2 != 0 and n < len(keymap_names):
-                    print(f"(DD)          {km_name}, ", end='')
+                    print(f"(DD)         {km_name}, ", end='')
                 elif n % 2 != 0 and n == len(keymap_names):
-                    print(f"(DD)          {km_name}]")
+                    print(f"(DD)         {km_name}]")
                 elif n == len(keymap_names): print(f"{km_name}]")
                 else: print(f"{km_name},")
                 n+=1

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -456,7 +456,8 @@ def transform_key(key, action, ctx):
                 f"NLK = '{ctx.numlock_on}'")
             n = 1
             for km_name in keymap_names:
-                if n == 1: print(f"(DD) KMAPS = [{km_name}, ", end='')
+                if n == 1 and len(keymap_names) > 1: print(f"(DD) KMAPS = [{km_name}, ", end='')
+                elif n == 1 and len(keymap_names) == 1: print(f"(DD) KMAPS = [{km_name}]")
                 elif n % 2 != 0 and n < len(keymap_names):
                     print(f"(DD)          {km_name}, ", end='')
                 elif n % 2 != 0 and n == len(keymap_names):

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -234,7 +234,7 @@ def log_combo_context(combo, ctx, keymap, _active_keymaps):
     output_str = f"{indent}{wrapped_items[0]}"
     for item in wrapped_items[1:]:
         if not item.startswith("'"):
-            item = ' ' + item
+            item = ' … ' + item
         output_str += f"\n{indent}{item}"
     print(output_str)
 

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -224,8 +224,8 @@ def log_combo_context(combo, ctx, keymap, _active_keymaps):
     import textwrap
 
     debug("")
-    debug(f"WM_CLS: '{ctx.wm_class}' | WM_NME: '{ctx.wm_name}'")
-    debug(f"DVN: '{ctx.device_name}' | CLK: '{ctx.capslock_on}' | NLK: '{ctx.numlock_on}'")
+    debug(f"WM_CLASS: '{ctx.wm_class}' | WM_NAME: '{ctx.wm_name}'")
+    debug(f"DEVICE: '{ctx.device_name}' | CAPS_LOCK: '{ctx.capslock_on}' | NUM_LOCK: '{ctx.numlock_on}'")
     debug(f'ACTIVE KEYMAPS:')
 
     indent = ' ' * 5

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -448,9 +448,14 @@ def transform_key(key, action, ctx):
             name_list = ", ".join(keymap_names)
             debug("")
             debug(
-                f"WM_CLS '{ctx.wm_class}' | "
-                f"DV '{ctx.device_name}' | "
-                f"KMAPS = [{name_list}]")
+                f"WM_CLS = '{ctx.wm_class}' | "
+                f"WM_NME = '{ctx.wm_name}'\n"
+                f"(DD) DVN = '{ctx.device_name}' | "
+                f"CLK = '{ctx.capslock_on}' | "
+                f"NLK = '{ctx.numlock_on}'\n"
+                f"(DD) Active Keymaps = ")
+            for km_name in keymap_names:
+                debug(f" KMAP: [{km_name}]")
             debug(f"  COMBO: {combo} => {keymap[combo]} [{keymap.name}]")
 
         held = get_pressed_states()

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -449,11 +449,12 @@ def transform_key(key, action, ctx):
             debug("")
             debug(
                 f"WM_CLS = '{ctx.wm_class}' | "
-                f"WM_NME = '{ctx.wm_name}'\n"
-                f"(DD) DVN = '{ctx.device_name}' | "
+                f"WM_NME = '{ctx.wm_name}'")
+            debug(
+                f"DVN = '{ctx.device_name}' | "
                 f"CLK = '{ctx.capslock_on}' | "
-                f"NLK = '{ctx.numlock_on}'\n"
-                f"(DD) Active Keymaps = ")
+                f"NLK = '{ctx.numlock_on}'")
+            debug(f"Active Keymaps = ")
             for km_name in keymap_names:
                 debug(f" KMAP: [{km_name}]")
             debug(f"  COMBO: {combo} => {keymap[combo]} [{keymap.name}]")

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -454,17 +454,20 @@ def transform_key(key, action, ctx):
                 f"DVN: '{ctx.device_name}' | "
                 f"CLK: '{ctx.capslock_on}' | "
                 f"NLK: '{ctx.numlock_on}'")
-            n = 1
-            for km_name in keymap_names:
-                if n == 1 and len(keymap_names) > 1: print(f"(DD) KMAPS: ['{km_name}', ", end='')
-                elif n == 1 and len(keymap_names) == 1: print(f"(DD) KMAPS: ['{km_name}']")
-                elif n % 2 != 0 and n < len(keymap_names):
-                    print(f"             '{km_name}', ", end='')
-                elif n % 2 != 0 and n == len(keymap_names):
-                    print(f"             '{km_name}']")
-                elif n == len(keymap_names): print(f"'{km_name}']")
-                else: print(f"'{km_name}',")
-                n+=1
+            prefix = "(DD) KMAPS:"
+            indent = " " * ( len(prefix) + 2 )
+            max_len = 80 - len(indent) - 2  # 2 is for quotes and comma
+            formatted_list = [f"'{keymap_names[0]}'"]
+            for name in keymap_names[1:]:
+                if len(formatted_list[-1]) + len(name) + 3 <= max_len:
+                    formatted_list[-1] += f", '{name}'"
+                else:
+                    formatted_list.append(f"'{name}'")
+            output_str = f"{prefix} [{formatted_list[0]}"
+            for line in formatted_list[1:]:
+                output_str += f",\n{indent}{line}"
+            output_str += "]"
+            print(output_str)
             debug(f"COMBO: {combo} => {keymap[combo]} in KMAP: ['{keymap.name}']")
 
         held = get_pressed_states()


### PR DESCRIPTION
Show all newly available properties in logging output, and reformat display of active keymaps. 

Sample output: 

```
(DD) WM_CLS = 'Gnome-terminal' | WM_NME = './bin/keyszer --flush -w -v -c ~/.config/kinto/kinto.py'
(DD) DVN = 'AT Translated Set 2 keyboard' | CLK = 'False' | NLK = 'False'
(DD) Active Keymaps = 
(DD)  KMAP: [OptSpecialChars toggles]
(DD)  KMAP: [OptSpecialChars - US]
(DD)  KMAP: [User hardware-specific customizations]
(DD)  KMAP: [Wordwise - not vscode]
(DD)  KMAP: [General Terminals]
(DD)  KMAP: [General GUI]
(DD)   COMBO: RCtrl-A => Ctrl-Shift-A [General Terminals]
```

<!--- Provide a quick summary of your changes in the Title above -->

### Changes

<!-- Reference a related issue (if one exists) so things are linked nicely: -->

<!-- `Resolves #12345`, etc. Then describe your changes... -->

**Checklist**

- [ ] Added tests (if necessary)
- [ ] Updated docs or README...
