### PR TITLE
Make shorter aliases available for all modifiers

### DIFF
--- a/src/keyszer/models/modifier.py
+++ b/src/keyszer/models/modifier.py
@@ -88,28 +88,28 @@ class Modifier:
 Modifier("R_CONTROL", aliases=["RCtrl", "RC"], key=Key.RIGHT_CTRL)
 Modifier("L_CONTROL", aliases=["LCtrl", "LC"], key=Key.LEFT_CTRL)
 Modifier("CONTROL", aliases=["Ctrl", "C"], keys=[Key.LEFT_CTRL, Key.RIGHT_CTRL])
-Modifier("R_ALT", aliases=["RAlt", "RA", "ROpt", "ROption"], key=Key.RIGHT_ALT)
-Modifier("L_ALT", aliases=["LAlt", "LA", "LOpt", "LOption"], key=Key.LEFT_ALT)
-Modifier("ALT", aliases=["Alt", "A", "Opt", "Option"], keys=[Key.LEFT_ALT, Key.RIGHT_ALT])
-Modifier("R_SHIFT", aliases=["RShift"], key=Key.RIGHT_SHIFT)
-Modifier("L_SHIFT", aliases=["LShift"], key=Key.LEFT_SHIFT)
-Modifier("SHIFT", aliases=["Shift"], keys=[Key.LEFT_SHIFT, Key.RIGHT_SHIFT])
+Modifier("R_ALT", aliases=["RAlt", "RA", "ROption", "ROpt", "RO"], key=Key.RIGHT_ALT)
+Modifier("L_ALT", aliases=["LAlt", "LA", "LOption", "LOpt", "LO"], key=Key.LEFT_ALT)
+Modifier("ALT", aliases=["Alt", "A", "Option", "Opt", "O"], keys=[Key.LEFT_ALT, Key.RIGHT_ALT])
+Modifier("R_SHIFT", aliases=["RShift", "RSh"], key=Key.RIGHT_SHIFT)
+Modifier("L_SHIFT", aliases=["LShift", "LSh"], key=Key.LEFT_SHIFT)
+Modifier("SHIFT", aliases=["Shift", "Sh"], keys=[Key.LEFT_SHIFT, Key.RIGHT_SHIFT])
 # purposely we do not have M, MA, or ML to give some distance from the fact
 # that these use to be aliases for Alt, not Meta... they may come back in
 # the future
 Modifier(
     "R_META",
-    aliases=["RSuper", "RWin", "RCommand", "RCmd", "RMeta"],
+    aliases=["RSuper", "RSup", "RS", "RWin", "RW", "RCommand", "RCmd", "RCd", "RMeta"],
     key=Key.RIGHT_META,
 )
 Modifier(
     "L_META",
-    aliases=["LSuper", "LWin", "LCommand", "LCmd", "LMeta"],
+    aliases=["LSuper", "LSup", "LS", "LWin", "LW", "LCommand", "LCmd", "LCd", "LMeta"],
     key=Key.LEFT_META,
 )
 Modifier(
     "META",
-    aliases=["Super", "Win", "Command", "Cmd", "Meta"],
+    aliases=["Super", "Sup", "S", "Win", "W", "Command", "Cmd", "Cd", "Meta"],
     keys=[Key.LEFT_META, Key.RIGHT_META],
 )
 


### PR DESCRIPTION
Since there was already "A", and "C", and the code doesn't seem to be bothered by having modifiers represented by single characters as long as they aren't in the final position in the shortcut combo, this adds short and "very short" aliases for as many modifiers as possible. 

New aliases: 
Sup, S, W, O, Sh, Cd, and their L/R variants. 

Shift and Command would be ambiguous with single character aliases, so are shortened to a minimum of 2 characters so they can still be distinguished from Super/Sup/S and Control/Ctrl/C. 

The logic of these shorter aliases should be intuitive for users that have already seen or used the "RC/LC/C" and "RA/LA/A" aliases. Leaving Meta alone for now, to avoid confusion with the past "M" = "Alt" that was removed.

<!--- Provide a quick summary of your changes in the Title above -->

### Changes

<!-- Reference a related issue (if one exists) so things are linked nicely: -->

<!-- `Resolves #12345`, etc. Then describe your changes... -->

**Checklist**

- [ ] Added tests (if necessary)
- [ ] Updated docs or README...
