### PR TITLE
Sleep delay after Unicode keystrokes

### DIFF
--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -198,7 +198,8 @@ def unicode_keystrokes(n):
             for digit in _digits(n, 16)
             for hexdigit in hex(digit)[2:].upper()
             ],
-        Key.ENTER
+        Key.ENTER,
+        sleep(1/10)
     ]
 
     return combo_list


### PR DESCRIPTION
Some combination of virtual machine input and/or issues with `ibus` or general input on KDE Plasma causes partial failures of Unicode keystrokes sequences. Symptoms include leaving the underlined "u" from the Shift-Ctrl-u combo, or leaving portions of the Unicode address on the screen, rather than successfully creating the Unicode character. 

When this problem occurs, the key sequences that follow after will not work as expected. The Unicode sequence acts like it has been interrupted or stuck in some buffer waiting for further input. 

Also, when the issue is happening it affects almost 100% of the attempts to use the Unicode keystrokes function. It is very repeatable. 

Minimum sleep delay that fixes this problem reliably is about 0.1s (1/10s), inserted after the Enter key keystroke that finishes the Unicode sequence. The delay makes no obvious difference in how quickly a Unicode character can be created, but restores the reliable use of Unicode sequences in macros.

<!--- Provide a quick summary of your changes in the Title above -->

### Changes

<!-- Reference a related issue (if one exists) so things are linked nicely: -->

<!-- `Resolves #12345`, etc. Then describe your changes... -->

**Checklist**

- [ ] Added tests (if necessary)
- [ ] Updated docs or README...
