### PR TITLE
Fix for macro and Unicode sequence reliability

### DIFF
--- a/src/keyszer/output.py
+++ b/src/keyszer/output.py
@@ -103,7 +103,7 @@ class Output:
         self.__update_pressed_keys(key, action)
         _uinput.write(ecodes.EV_KEY, key, action)
         debug(action, key, time.time(), ctx="OO")
-        self.__send_sync()
+        # self.__send_sync()
 
     def send_combo(self, combo):
         released_mod_keys = []


### PR DESCRIPTION
Removing the sync line from the `send_key_action` function fixes problems with macros and Unicode keystroke sequences that fail partway through.

This change appears to resolve a long-standing problem with macro keystroke sequences and Unicode keystroke sequences failing partway through in various circumstances. 

No negative side effects are known or have yet been observed. 