### PR TITLE
Let string and Unicode processors adapt to CapsLock LED state

### DIFF
--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -166,8 +166,7 @@ def to_US_keystrokes(s):
         combo_list = []
         for c in s:
             if ord(c) > 127:
-                unicode_keystrokes(ord(c))(ctx)    # extra "()" updates global variable
-                combo_list.extend(unicode_combo_list)
+                combo_list.extend(unicode_keystrokes(ord(c))(ctx))
             elif c.isupper():
                 if ctx.capslock_on: combo_list.append(combo(c))
                 else: combo_list.append(combo("Shift-" + c))

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -150,8 +150,6 @@ class TypingTooLong(Exception):
 class UnicodeNumberToolarge(Exception):
     pass
 
-unicode_combo_list = []
-
 
 def to_US_keystrokes(s):
     """
@@ -199,7 +197,6 @@ def unicode_keystrokes(n):
     if (n > 0x10ffff):
         raise UnicodeNumberToolarge(f"{hex(n)} too large for Unicode keyboard entry.")
     def _unicode_keystrokes(ctx):
-        global unicode_combo_list
         combo_list = [
             combo("Shift-Ctrl-u"),  # requires "ibus" or "fctix" as input manager?
             *[Key[hexdigit]
@@ -211,7 +208,6 @@ def unicode_keystrokes(n):
         if ctx.capslock_on:
             combo_list.insert(0, Key.CAPSLOCK)
             combo_list.append(Key.CAPSLOCK)
-        unicode_combo_list = combo_list
         return combo_list
 
     return _unicode_keystrokes

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -160,9 +160,9 @@ def to_US_keystrokes(s):
 
     Warn: Almost certainly not going to work with non-US keymaps.
     """
+    if len(s) > 100:
+        raise TypingTooLong("`to_keystrokes` only supports strings of 100 characters or less")
     def _to_keystrokes(ctx):
-        if len(s) > 100:
-            raise TypingTooLong("`to_keystrokes` only supports strings of 100 characters or less")
         combo_list = []
         for c in s:
             if ord(c) > 127:
@@ -197,17 +197,17 @@ def _digits(n, base):
 
 def unicode_keystrokes(n):
     """Turn Unicode number into keystroke commands"""
+    if (n > 0x10ffff):
+        raise UnicodeNumberToolarge(f"{hex(n)} too large for Unicode keyboard entry.")
     def _unicode_keystrokes(ctx):
-        if (n > 0x10ffff):
-            raise UnicodeNumberToolarge(f"{hex(n)} too large for Unicode keyboard entry.")
         global unicode_combo_list
         combo_list = [
-            combo("Shift-Ctrl-u"),  # requires "ibus" as input manager
+            combo("Shift-Ctrl-u"),  # requires "ibus" or "fctix" as input manager?
             *[Key[hexdigit]
                 for digit in _digits(n, 16)
                 for hexdigit in hex(digit)[2:].upper()
                 ],
-            Key.ENTER
+            Key.ENTER,
         ]
         if ctx.capslock_on:
             combo_list.insert(0, Key.CAPSLOCK)

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -164,7 +164,7 @@ def to_US_keystrokes(s):
         combo_list = []
         for c in s:
             if ord(c) > 127:
-                combo_list.extend(unicode_keystrokes(ord(c))(ctx))
+                combo_list.append(unicode_keystrokes(ord(c)))
             elif c.isupper():
                 if ctx.capslock_on: combo_list.append(combo(c))
                 else: combo_list.append(combo("Shift-" + c))

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+import inspect
 
 from evdev import ecodes
 
@@ -462,7 +463,7 @@ def transform_key(key, action, ctx):
             if not _output.is_mod_pressed(ks.key):
                 ks.spent = True
         debug("spent modifiers", [_.key for _ in held if _.spent])
-        reset_mode = handle_commands(keymap[combo], key, action, combo)
+        reset_mode = handle_commands(keymap[combo], key, action, ctx, combo)
         if reset_mode:
             _active_keymaps = None
         return
@@ -525,7 +526,7 @@ def auto_sticky(combo, input_combo):
 # ─── COMMAND PROCESSING ───────────────────────────────────────────────────────
 
 
-def handle_commands(commands, key, action, input_combo=None):
+def handle_commands(commands, key, action, ctx, input_combo=None):
     """
     returns: reset_mode (True/False) if this is True, _active_keymaps will be reset
     """
@@ -548,7 +549,11 @@ def handle_commands(commands, key, action, input_combo=None):
         for command in commands:
             if callable(command):
                 # very likely we're just passing None forwards here but that OK
-                reset_mode = handle_commands(command(), key, action)
+                cmd_param_cnt = len(inspect.signature(command).parameters)
+                if cmd_param_cnt == 0:
+                    reset_mode = handle_commands(command(), key, action, ctx)
+                else:
+                    reset_mode = handle_commands(command(ctx), key, action, ctx)
                 # if the command wants to disable reset, lets propagate that
                 if reset_mode is False:
                     return False


### PR DESCRIPTION
<!--- Provide a quick summary of your changes in the Title above -->

### Changes

Updates `config_api` and `transform` to pass the context object to commands (filtering for whether or not the target function is able to accept the new context parameter), and allowing the string and Unicode processor helper functions to adapt their output to deal with CapsLock being enabled. 

<!-- Reference a related issue (if one exists) so things are linked nicely: -->

Should resolve issue #128 

<!-- `Resolves #12345`, etc. Then describe your changes... -->

**Checklist**

- [X] Added tests (if necessary)

