### PR TITLE
Add (COMPOUND_TEXT) fix to get_actual_window()

### DIFF
--- a/src/keyszer/xorg.py
+++ b/src/keyszer/xorg.py
@@ -59,7 +59,6 @@ def get_actual_window(window):
     # use _NET_WM_NAME string instead of WM_NAME to bypass (COMPOUND_TEXT) encoding problems
     wmname  = window.get_full_text_property(_display.get_atom("_NET_WM_NAME"))
     wmclass = window.get_wm_class()
-    debug(f'### get_actual_window():\n\t{wmname = }\n\t{wmclass = }')
     # workaround for Java app
     # https://github.com/JetBrains/jdk8u_jdk/blob/master/src/solaris/classes/sun/awt/X11/XFocusProxyWindow.java#L35
     if (wmclass is None and wmname is None) or "FocusProxy" in (wmclass or ""):

--- a/src/keyszer/xorg.py
+++ b/src/keyszer/xorg.py
@@ -56,19 +56,16 @@ def get_xorg_context():
 
 
 def get_actual_window(window):
-    try:
-        # use _NET_WM_NAME string instead of WM_NAME to bypass (COMPOUND_TEXT) encoding problems
-        wmname  = window.get_full_text_property(_display.get_atom("_NET_WM_NAME"))
-        wmclass = window.get_wm_class()
-        # workaround for Java app
-        # https://github.com/JetBrains/jdk8u_jdk/blob/master/src/solaris/classes/sun/awt/X11/XFocusProxyWindow.java#L35
-        if (wmclass is None and wmname is None) or "FocusProxy" in wmclass:
-            parent_window = window.query_tree().parent
-            if parent_window:
-                return get_actual_window(parent_window)
-            return None
-
-        return window
-    # TODO: more specific rescue here
-    except Exception:
+    # use _NET_WM_NAME string instead of WM_NAME to bypass (COMPOUND_TEXT) encoding problems
+    wmname  = window.get_full_text_property(_display.get_atom("_NET_WM_NAME"))
+    wmclass = window.get_wm_class()
+    debug(f'### get_actual_window():\n\t{wmname = }\n\t{wmclass = }')
+    # workaround for Java app
+    # https://github.com/JetBrains/jdk8u_jdk/blob/master/src/solaris/classes/sun/awt/X11/XFocusProxyWindow.java#L35
+    if (wmclass is None and wmname is None) or "FocusProxy" in (wmclass or ""):
+        parent_window = window.query_tree().parent
+        if parent_window:
+            return get_actual_window(parent_window)
         return None
+
+    return window

--- a/src/keyszer/xorg.py
+++ b/src/keyszer/xorg.py
@@ -26,14 +26,14 @@ def get_xorg_context():
     try:
         _display = _display or Display()
         wm_class = ""
-        wm_name = ""
+        wm_name  = ""
 
         input_focus = _display.get_input_focus().focus
-        window = get_actual_window(input_focus)
+        window      = get_actual_window(input_focus)
         if window:
             # use _NET_WM_NAME string instead of WM_NAME to bypass (COMPOUND_TEXT) encoding problems
             wm_name = window.get_full_text_property(_display.get_atom("_NET_WM_NAME"))
-            pair = window.get_wm_class()
+            pair    = window.get_wm_class()
             if pair:
                 wm_class = str(pair[1])
 
@@ -57,7 +57,8 @@ def get_xorg_context():
 
 def get_actual_window(window):
     try:
-        wmname = window.get_wm_name()
+        # use _NET_WM_NAME string instead of WM_NAME to bypass (COMPOUND_TEXT) encoding problems
+        wmname  = window.get_full_text_property(_display.get_atom("_NET_WM_NAME"))
         wmclass = window.get_wm_class()
         # workaround for Java app
         # https://github.com/JetBrains/jdk8u_jdk/blob/master/src/solaris/classes/sun/awt/X11/XFocusProxyWindow.java#L35
@@ -71,5 +72,3 @@ def get_actual_window(window):
     # TODO: more specific rescue here
     except Exception:
         return None
-
-    return window


### PR DESCRIPTION
The get_actual_window() function is doing its own lookup of the WM_NAME, and was still using the older window attribute. Not a showstopper problem, but would definitely result in an incorrect WM_NAME whenever the queried window had a (COMPOUND_TEXT) encoded WM_NAME. Generally this is due to a non-ASCII character being in the WM_NAME, and this is the case with the JetBrain Java apps that the get_actual_window() function was designed to deal with. 

Propagating the same fix from the get_xorg_context() function that gets the UTF-8 encoded _NET_WM_NAME instead of WM_NAME. 

Also the redundant "return window" line at the very end was never being accessed (orphaned line), and should probably be removed.

<!--- Provide a quick summary of your changes in the Title above -->

### Changes

<!-- Reference a related issue (if one exists) so things are linked nicely: -->

<!-- `Resolves #12345`, etc. Then describe your changes... -->

**Checklist**

- [ ] Added tests (if necessary)
- [ ] Updated docs or README...
