### PR TITLE
Add throttle delays to send_combo normal keystroke

### DIFF
--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -41,16 +41,26 @@ TIMEOUT_DEFAULTS = {
 # multipurpose timeout
 _TIMEOUTS = TIMEOUT_DEFAULTS
 
-# delay globals to fix Unicode entry sequence and macro failures
-THROTTLE_DELAYS = {'unicode_delay_ms': 0, 'keystroke_delay_ms': 0}
+# global dict of delay values used to mitigate Unicode entry sequence and macro or combo failures
+THROTTLE_DELAY_DEFAULTS = {
+    'unicode_delay_ms': 0,
+    'key_pre_delay_ms': 0,
+    'key_post_delay_ms': 0,
+}
+_THROTTLES = THROTTLE_DELAY_DEFAULTS
 
-def throttle_delays(unicode_delay_ms=0, keystroke_delay_ms=0):
-    _ud, _kd = unicode_delay_ms, keystroke_delay_ms
-    if _ud != 0 or _kd != 0: debug(f'Throttle delays: {unicode_delay_ms = }, {keystroke_delay_ms = }', ctx="II")
-    if _ud <= 100 and _ud >= 0 and isinstance(_ud, int): THROTTLE_DELAYS.update({'unicode_delay_ms': _ud})
-    else: debug(f'ERROR: Unicode delay throttle must be int 0 to 100 ms. Defaulting to 0 ms.', ctx="EE")
-    if _kd <= 150 and _kd >= 0 and isinstance(_kd, int): THROTTLE_DELAYS.update({'keystroke_delay_ms': _kd})
-    else: debug(f'ERROR: Keystroke delay throttle must be int 0 to 150 ms. Defaulting to 0 ms.', ctx="EE")
+def throttle_delays(unicode_delay_ms=0,key_pre_delay_ms=0, key_post_delay_ms=0):
+    _ud, _kpre, _kpost = unicode_delay_ms, key_pre_delay_ms, key_post_delay_ms
+    if 100 >= _ud >= 0 and isinstance(_ud, int): _THROTTLES.update({'unicode_delays_ms': _ud})
+    else: debug(f'throttle_delays(): unicode_delay_ms must be int 0 to 100 ms. Defaulting to 0 ms.', ctx="EE")
+    if 100 >= _kpre >= 0 and isinstance(_kpre, int): _THROTTLES.update({'key_pre_delay_ms': _kpre})
+    else: debug(f'throttle_delays(): key_pre_delay_ms must be int 0 to 100 ms. Defaulting to 0 ms.', ctx="EE")
+    if 100 >= _kpost >= 0 and isinstance(_kpost, int): _THROTTLES.update({'key_post_delay_ms': _kpost})
+    else: debug(f'throttle_delays(): key_post_delay_ms must be int 0 to 100 ms. Defaulting to 0 ms.', ctx="EE")
+    # Show values in log if user sets any custom delays
+    if any(_THROTTLES.values()) != 0:
+        debug(f'THROTTLES: Custom throttle delay values set by user: \
+                \n\t{unicode_delay_ms = }, {key_pre_delay_ms = }, {key_post_delay_ms = }', ctx="II")
 
 # for use with throttle delays
 def sleep_ms(msec):
@@ -213,9 +223,9 @@ def unicode_keystrokes(n):
             for digit in _digits(n, 16)
             for hexdigit in hex(digit)[2:].upper()
             ],
-        sleep_ms(THROTTLE_DELAYS['unicode_delay_ms']),
+        sleep_ms(_THROTTLES['unicode_delay_ms']),
         Key.ENTER,
-        sleep_ms(THROTTLE_DELAYS['unicode_delay_ms']),
+        sleep_ms(_THROTTLES['unicode_delay_ms']),
     ]
 
     return combo_list

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -43,25 +43,20 @@ _TIMEOUTS = TIMEOUT_DEFAULTS
 
 # global dict of delay values used to mitigate Unicode entry sequence and macro or combo failures
 THROTTLE_DELAY_DEFAULTS = {
-    'unicode_delay_ms': 0,
     'key_pre_delay_ms': 0,
     'key_post_delay_ms': 0,
 }
 _THROTTLES = THROTTLE_DELAY_DEFAULTS
 
-def throttle_delays(unicode_delay_ms=0,key_pre_delay_ms=0, key_post_delay_ms=0):
-    _ud, _kpre, _kpost = unicode_delay_ms, key_pre_delay_ms, key_post_delay_ms
-    ms_min, ms_max = 0.0, 150.0
-    if ms_min <= _ud <= ms_max: _THROTTLES.update({'unicode_delays_ms': _ud})
-    else: error(f'throttle_delays(): unicode_delay_ms must be {ms_min} to {ms_max} ms. Defaulting to 0 ms.')
+def throttle_delays(key_pre_delay_ms=0, key_post_delay_ms=0):
+    _kpre, _kpost, ms_min, ms_max = key_pre_delay_ms, key_post_delay_ms, 0.0, 150.0
     if ms_min <= _kpre <= ms_max: _THROTTLES.update({'key_pre_delay_ms': _kpre})
     else: error(f'throttle_delays(): key_pre_delay_ms must be {ms_min} to {ms_max} ms. Defaulting to 0 ms.')
     if ms_min <= _kpost <= ms_max: _THROTTLES.update({'key_post_delay_ms': _kpost})
     else: error(f'throttle_delays(): key_post_delay_ms must be {ms_min} to {ms_max} ms. Defaulting to 0 ms.')
-    # Show values in log if user sets any custom delays
+    # Show values in log if user sets custom delays
     if any(_THROTTLES.values()):
-        debug(f'THROTTLES: Custom throttle delay values set by user: \
-                \n\t{unicode_delay_ms = }, {key_pre_delay_ms = }, {key_post_delay_ms = }', ctx="II")
+        debug(f'THROTTLES: {key_pre_delay_ms = }, {key_post_delay_ms = }')
 
 # for use with throttle delays
 def sleep_ms(msec):
@@ -224,9 +219,7 @@ def unicode_keystrokes(n):
             for digit in _digits(n, 16)
             for hexdigit in hex(digit)[2:].upper()
             ],
-        sleep_ms(_THROTTLES['unicode_delay_ms']),
         Key.ENTER,
-        sleep_ms(_THROTTLES['unicode_delay_ms']),
     ]
 
     return combo_list

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -51,14 +51,15 @@ _THROTTLES = THROTTLE_DELAY_DEFAULTS
 
 def throttle_delays(unicode_delay_ms=0,key_pre_delay_ms=0, key_post_delay_ms=0):
     _ud, _kpre, _kpost = unicode_delay_ms, key_pre_delay_ms, key_post_delay_ms
-    if 100 >= _ud >= 0 and isinstance(_ud, int): _THROTTLES.update({'unicode_delays_ms': _ud})
-    else: debug(f'throttle_delays(): unicode_delay_ms must be int 0 to 100 ms. Defaulting to 0 ms.', ctx="EE")
-    if 150 >= _kpre >= 0 and isinstance(_kpre, int): _THROTTLES.update({'key_pre_delay_ms': _kpre})
-    else: debug(f'throttle_delays(): key_pre_delay_ms must be int 0 to 150 ms. Defaulting to 0 ms.', ctx="EE")
-    if 150 >= _kpost >= 0 and isinstance(_kpost, int): _THROTTLES.update({'key_post_delay_ms': _kpost})
-    else: debug(f'throttle_delays(): key_post_delay_ms must be int 0 to 150 ms. Defaulting to 0 ms.', ctx="EE")
+    ms_min, ms_max = 0.0, 150.0
+    if ms_min <= _ud <= ms_max: _THROTTLES.update({'unicode_delays_ms': _ud})
+    else: debug(f'throttle_delays(): unicode_delay_ms must be {ms_min} to {ms_max} ms. Defaulting to 0 ms.', ctx="EE")
+    if ms_min <= _kpre <= ms_max: _THROTTLES.update({'key_pre_delay_ms': _kpre})
+    else: debug(f'throttle_delays(): key_pre_delay_ms must be {ms_min} to {ms_max} ms. Defaulting to 0 ms.', ctx="EE")
+    if ms_min <= _kpost <= ms_max: _THROTTLES.update({'key_post_delay_ms': _kpost})
+    else: debug(f'throttle_delays(): key_post_delay_ms must be {ms_min} to {ms_max} ms. Defaulting to 0 ms.', ctx="EE")
     # Show values in log if user sets any custom delays
-    if any(_THROTTLES.values()) != 0:
+    if any(_THROTTLES.values()):
         debug(f'THROTTLES: Custom throttle delay values set by user: \
                 \n\t{unicode_delay_ms = }, {key_pre_delay_ms = }, {key_post_delay_ms = }', ctx="II")
 

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -7,7 +7,7 @@ import os
 import inspect
 from inspect import signature
 
-from .lib.logger import error
+from .lib.logger import error, debug
 from .models.action import Action
 from .models.combo import Combo, ComboHint
 from .models.trigger import Trigger

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -53,10 +53,10 @@ def throttle_delays(unicode_delay_ms=0,key_pre_delay_ms=0, key_post_delay_ms=0):
     _ud, _kpre, _kpost = unicode_delay_ms, key_pre_delay_ms, key_post_delay_ms
     if 100 >= _ud >= 0 and isinstance(_ud, int): _THROTTLES.update({'unicode_delays_ms': _ud})
     else: debug(f'throttle_delays(): unicode_delay_ms must be int 0 to 100 ms. Defaulting to 0 ms.', ctx="EE")
-    if 100 >= _kpre >= 0 and isinstance(_kpre, int): _THROTTLES.update({'key_pre_delay_ms': _kpre})
-    else: debug(f'throttle_delays(): key_pre_delay_ms must be int 0 to 100 ms. Defaulting to 0 ms.', ctx="EE")
-    if 100 >= _kpost >= 0 and isinstance(_kpost, int): _THROTTLES.update({'key_post_delay_ms': _kpost})
-    else: debug(f'throttle_delays(): key_post_delay_ms must be int 0 to 100 ms. Defaulting to 0 ms.', ctx="EE")
+    if 150 >= _kpre >= 0 and isinstance(_kpre, int): _THROTTLES.update({'key_pre_delay_ms': _kpre})
+    else: debug(f'throttle_delays(): key_pre_delay_ms must be int 0 to 150 ms. Defaulting to 0 ms.', ctx="EE")
+    if 150 >= _kpost >= 0 and isinstance(_kpost, int): _THROTTLES.update({'key_post_delay_ms': _kpost})
+    else: debug(f'throttle_delays(): key_post_delay_ms must be int 0 to 150 ms. Defaulting to 0 ms.', ctx="EE")
     # Show values in log if user sets any custom delays
     if any(_THROTTLES.values()) != 0:
         debug(f'THROTTLES: Custom throttle delay values set by user: \

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -53,11 +53,11 @@ def throttle_delays(unicode_delay_ms=0,key_pre_delay_ms=0, key_post_delay_ms=0):
     _ud, _kpre, _kpost = unicode_delay_ms, key_pre_delay_ms, key_post_delay_ms
     ms_min, ms_max = 0.0, 150.0
     if ms_min <= _ud <= ms_max: _THROTTLES.update({'unicode_delays_ms': _ud})
-    else: debug(f'throttle_delays(): unicode_delay_ms must be {ms_min} to {ms_max} ms. Defaulting to 0 ms.', ctx="EE")
+    else: error(f'throttle_delays(): unicode_delay_ms must be {ms_min} to {ms_max} ms. Defaulting to 0 ms.')
     if ms_min <= _kpre <= ms_max: _THROTTLES.update({'key_pre_delay_ms': _kpre})
-    else: debug(f'throttle_delays(): key_pre_delay_ms must be {ms_min} to {ms_max} ms. Defaulting to 0 ms.', ctx="EE")
+    else: error(f'throttle_delays(): key_pre_delay_ms must be {ms_min} to {ms_max} ms. Defaulting to 0 ms.')
     if ms_min <= _kpost <= ms_max: _THROTTLES.update({'key_post_delay_ms': _kpost})
-    else: debug(f'throttle_delays(): key_post_delay_ms must be {ms_min} to {ms_max} ms. Defaulting to 0 ms.', ctx="EE")
+    else: error(f'throttle_delays(): key_post_delay_ms must be {ms_min} to {ms_max} ms. Defaulting to 0 ms.')
     # Show values in log if user sets any custom delays
     if any(_THROTTLES.values()):
         debug(f'THROTTLES: Custom throttle delay values set by user: \

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -41,27 +41,20 @@ TIMEOUT_DEFAULTS = {
 # multipurpose timeout
 _TIMEOUTS = TIMEOUT_DEFAULTS
 
-from .output import set_keystroke_delay
+# delay globals to fix Unicode entry sequence and macro failures
+THROTTLE_DELAYS = {'unicode_delay_ms': 0, 'keystroke_delay_ms': 0}
 
-# delay to fix Unicode entry sequence failures
-unicode_delay_ms = 0
+def throttle_delays(unicode_delay_ms=0, keystroke_delay_ms=0):
+    _ud, _kd = unicode_delay_ms, keystroke_delay_ms
+    if _ud != 0 or _kd != 0: debug(f'Throttle delays: {unicode_delay_ms = }, {keystroke_delay_ms = }', ctx="II")
+    if _ud <= 100 and _ud >= 0 and isinstance(_ud, int): THROTTLE_DELAYS.update({'unicode_delay_ms': _ud})
+    else: debug(f'ERROR: Unicode delay throttle must be int 0 to 100 ms. Defaulting to 0 ms.', ctx="EE")
+    if _kd <= 150 and _kd >= 0 and isinstance(_kd, int): THROTTLE_DELAYS.update({'keystroke_delay_ms': _kd})
+    else: debug(f'ERROR: Keystroke delay throttle must be int 0 to 150 ms. Defaulting to 0 ms.', ctx="EE")
 
-
-def throttle_delays(unicode_delay=0, keystroke_delay=0):
-    global unicode_delay_ms
-    _ud = unicode_delay
-    _kd = keystroke_delay
-    if _ud <= 100 and _ud >= 0 and isinstance(_ud, int):
-        unicode_delay_ms = _ud / 1000
-    else:
-        unicode_delay_ms = 0
-        print(f'(EE) ERROR: Unicode delay throttle must be int 1 to 100 ms. Defaulting to 0 ms.')
-    if _kd <= 150 and _kd >= 0 and isinstance(_kd, int):
-        set_keystroke_delay(_kd)
-    else:
-        set_keystroke_delay(0)
-        print(f'(EE) ERROR: Keystroke delay throttle must be int 1 to 150 ms. Defaulting to 0 ms.')
-
+# for use with throttle delays
+def sleep_ms(usec):
+    return time.sleep(usec / 1000)
 
 # keymaps
 _KEYMAPS = []
@@ -220,9 +213,9 @@ def unicode_keystrokes(n):
             for digit in _digits(n, 16)
             for hexdigit in hex(digit)[2:].upper()
             ],
-        sleep(unicode_delay_ms),
+        sleep_ms(THROTTLE_DELAYS['unicode_delay_ms']),
         Key.ENTER,
-        sleep(unicode_delay_ms),
+        sleep_ms(THROTTLE_DELAYS['unicode_delay_ms']),
     ]
 
     return combo_list

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -41,6 +41,28 @@ TIMEOUT_DEFAULTS = {
 # multipurpose timeout
 _TIMEOUTS = TIMEOUT_DEFAULTS
 
+from .output import set_keystroke_delay
+
+# delay to fix Unicode entry sequence failures
+unicode_delay_ms = 0
+
+
+def throttle_delays(unicode_delay=0, keystroke_delay=0):
+    global unicode_delay_ms
+    _ud = unicode_delay
+    _kd = keystroke_delay
+    if _ud <= 100 and _ud >= 0 and isinstance(_ud, int):
+        unicode_delay_ms = _ud / 1000
+    else:
+        unicode_delay_ms = 0
+        print(f'(EE) ERROR: Unicode delay throttle must be int 1 to 100 ms. Defaulting to 0 ms.')
+    if _kd <= 150 and _kd >= 0 and isinstance(_kd, int):
+        set_keystroke_delay(_kd)
+    else:
+        set_keystroke_delay(0)
+        print(f'(EE) ERROR: Keystroke delay throttle must be int 1 to 150 ms. Defaulting to 0 ms.')
+
+
 # keymaps
 _KEYMAPS = []
 
@@ -198,7 +220,9 @@ def unicode_keystrokes(n):
             for digit in _digits(n, 16)
             for hexdigit in hex(digit)[2:].upper()
             ],
-        Key.ENTER
+        sleep(unicode_delay_ms),
+        Key.ENTER,
+        sleep(unicode_delay_ms),
     ]
 
     return combo_list

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -53,8 +53,8 @@ def throttle_delays(unicode_delay_ms=0, keystroke_delay_ms=0):
     else: debug(f'ERROR: Keystroke delay throttle must be int 0 to 150 ms. Defaulting to 0 ms.', ctx="EE")
 
 # for use with throttle delays
-def sleep_ms(usec):
-    return time.sleep(usec / 1000)
+def sleep_ms(msec):
+    return time.sleep(msec / 1000)
 
 # keymaps
 _KEYMAPS = []

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -48,19 +48,21 @@ THROTTLE_DELAY_DEFAULTS = {
 }
 _THROTTLES = THROTTLE_DELAY_DEFAULTS
 
-def throttle_delays(key_pre_delay_ms=0, key_post_delay_ms=0):
-    _kpre, _kpost, ms_min, ms_max = key_pre_delay_ms, key_post_delay_ms, 0.0, 150.0
-    if ms_min <= _kpre <= ms_max: _THROTTLES.update({'key_pre_delay_ms': _kpre})
-    else: error(f'throttle_delays(): key_pre_delay_ms must be {ms_min} to {ms_max} ms. Defaulting to 0 ms.')
-    if ms_min <= _kpost <= ms_max: _THROTTLES.update({'key_post_delay_ms': _kpost})
-    else: error(f'throttle_delays(): key_post_delay_ms must be {ms_min} to {ms_max} ms. Defaulting to 0 ms.')
-    # Show values in log if user sets custom delays
-    if any(_THROTTLES.values()):
-        debug(f'THROTTLES: {key_pre_delay_ms = }, {key_post_delay_ms = }')
 
-# for use with throttle delays
-def sleep_ms(msec):
-    return time.sleep(msec / 1000)
+def clamp(num, min_value, max_value):
+    return max(min(num, max_value), min_value)
+
+
+def throttle_delays(key_pre_delay_ms=0, key_post_delay_ms=0):
+    ms_min, ms_max = 0.0, 150.0
+    if any([not(ms_min <= e <= ms_max) for e in [key_pre_delay_ms, key_post_delay_ms]]):
+        error(f'Throttle delay value out of range. Clamping to valid range: {ms_min} to {ms_max}.')
+    _THROTTLES.update({ 'key_pre_delay_ms' : clamp(key_pre_delay_ms, ms_min, ms_max), 
+                        'key_post_delay_ms': clamp(key_post_delay_ms, ms_min, ms_max) })
+    debug(f'THROTTLES:\
+        \n\tPre-key  : {_THROTTLES["key_pre_delay_ms"]}\
+        \n\tPost-key : {_THROTTLES["key_post_delay_ms"]}')
+
 
 # keymaps
 _KEYMAPS = []

--- a/src/keyszer/output.py
+++ b/src/keyszer/output.py
@@ -38,6 +38,8 @@ _uinput = None
 
 # for use with throttle delays
 def sleep_ms(msec):
+    if msec == 0:
+        return
     return time.sleep(msec / 1000)
 
 

--- a/src/keyszer/output.py
+++ b/src/keyszer/output.py
@@ -6,7 +6,7 @@ from .lib.logger import debug
 from .models.action import PRESS, RELEASE
 from .models.combo import Combo
 from .models.modifier import Modifier
-from .config_api import sleep_ms, _THROTTLES
+from .config_api import _THROTTLES
 
 
 VIRT_DEVICE_PREFIX = "Keyszer (virtual)"
@@ -34,6 +34,11 @@ _MOUSE_BUTTONS = {
 _KEYBOARD_KEYS.update(_MOUSE_BUTTONS)
 
 _uinput = None
+
+
+# for use with throttle delays
+def sleep_ms(msec):
+    return time.sleep(msec / 1000)
 
 
 def real_uinput():

--- a/src/keyszer/output.py
+++ b/src/keyszer/output.py
@@ -6,7 +6,7 @@ from .lib.logger import debug
 from .models.action import PRESS, RELEASE
 from .models.combo import Combo
 from .models.modifier import Modifier
-from .config_api import sleep_ms, THROTTLE_DELAYS
+from .config_api import sleep_ms, _THROTTLES
 
 
 VIRT_DEVICE_PREFIX = "Keyszer (virtual)"
@@ -127,12 +127,10 @@ class Output:
             pressed_mod_keys.append(key)
 
         # normal key portion of the combo
-        # pre keystroke delay can be a little shorter than post
-        sleep_ms(THROTTLE_DELAYS['keystroke_delay_ms'] / 1.5)
+        sleep_ms(_THROTTLES['key_pre_delay_ms'])
         self.send_key_action(combo.key, PRESS)
         self.send_key_action(combo.key, RELEASE)
-        # post keystroke delay slightly more effective?
-        sleep_ms(THROTTLE_DELAYS['keystroke_delay_ms'])
+        sleep_ms(_THROTTLES['key_post_delay_ms'])
 
         for modifier in reversed(pressed_mod_keys):
             self.send_key_action(modifier, RELEASE)

--- a/src/keyszer/output.py
+++ b/src/keyszer/output.py
@@ -10,6 +10,21 @@ from .models.modifier import Modifier
 
 VIRT_DEVICE_PREFIX = "Keyszer (virtual)"
 
+# keystroke delays to work around modifier timing problems
+key_pre_delay_ms = 0
+key_post_delay_ms = 0
+
+
+def set_keystroke_delay(keystroke_delay=0):
+    """Used from config_api to pass keystroke delay from user's config."""
+    _kd = keystroke_delay
+    global key_pre_delay_ms
+    global key_post_delay_ms
+    key_pre_delay_ms = round( (_kd / 1500), 3) if _kd <= 200 and _kd > 0 else 0
+    key_post_delay_ms = round( (_kd / 1000), 3) if _kd <= 200 and _kd > 0 else 0
+    if _kd != 0:
+        debug(f'Keystroke delays: {key_pre_delay_ms = }, {key_post_delay_ms = }')
+
 
 # Remove all buttons so udev doesn't think keyszer is a joystick
 _KEYBOARD_KEYS = ecodes.keys.keys() - ecodes.BTN
@@ -127,8 +142,10 @@ class Output:
             pressed_mod_keys.append(key)
 
         # normal key portion of the combo
+        time.sleep(key_pre_delay_ms)
         self.send_key_action(combo.key, PRESS)
         self.send_key_action(combo.key, RELEASE)
+        time.sleep(key_post_delay_ms)
 
         for modifier in reversed(pressed_mod_keys):
             self.send_key_action(modifier, RELEASE)


### PR DESCRIPTION
### Changes

Modifies `config_api` to add a new function (throttle_delays) that the user can optionally call from their config, to insert two possible sleep delays in `output`. 

Usage from config: 

```py
throttle_delays(
    key_pre_delay_ms    = 40,    # default: 0 ms, range: 0 to 150 ms, suggested: 1-50 ms
    key_post_delay_ms   = 70,    # default: 0 ms, range: 0 to 150 ms, suggested: 1-100 ms
)
```

Delay variables default to zero if there is no user input (or if input value is out of range), leaving no effect on the respective areas. 

As shown in the comments in the example, the range is capped at 0 to 150 milliseconds for the keystroke delays to add to `send_combo`. A shorter "pre-keystroke" delay and longer "post-keystroke" delay may maximize effectiveness with the shortest possible delay for each situation. 

The locations of the throttles are designed and tested to minimize the affect on using shortcut combos and regular typing. 

### Related issues

 As noted in more than one issue previously, sometimes the output from the virtual keyboard seems to be getting misinterpreted by the receiving application window, leading to failing Unicode sequences, failing hotkeys/shortcut combos, and/or macro string output being corrupted in various ways. Mostly regarding the apparent timing of when the application believes the modifier keys are pressed or released. When this problem occurs, the only apparent solution to this appears to be throttling the speed of the emitted keystrokes until the issue disappears. 

**Checklist**

- [x] Updated docs or README...
