### PR TITLE
Add environment overrides API function

### DIFF
--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -64,6 +64,27 @@ def throttle_delays(key_pre_delay_ms=0, key_post_delay_ms=0):
         \n\tPost-key : {_THROTTLES["key_post_delay_ms"]}')
 
 
+ENVIRONMENT_OVERRIDES = {
+    'override_distro_name' : None,     # Ubuntu, Fedora, KDE Neon, Linux Mint, Pop!_OS, etc.
+    'override_session_type': None,     # x11, wayland, mir, etc.
+    'override_desktop_env' : None,     # gnome, kde, xfce, sway, hypr, etc.
+}
+
+
+# API function to inject environment if problems with auto-detection
+def environment_overrides(
+    override_distro_name=None, 
+    override_session_type=None, 
+    override_desktop_env=None
+    ):
+    ENVIRONMENT_OVERRIDES.update({
+        'override_distro_name' : override_distro_name,
+        'override_session_type': override_session_type.casefold(),
+        'override_desktop_env' : override_desktop_env.casefold()
+    })
+    debug(f'CONFIG_API: User configured environment:\n\t{ENVIRONMENT_OVERRIDES}')
+
+ 
 # keymaps
 _KEYMAPS = []
 


### PR DESCRIPTION
### Changes

Add a dict and function to support user injected overrides to manually specify the environment from config. 

Naming emphasizes to the user that the use of the API will short-circuit (override) any auto-detection features the keymapper may implement or have available. If anything is pushed from config via the function, other areas will be designed to accept these pushed values as taking precedence over the detection algorithms. 

The only good reason to use the API is if the detection algorithms fail, such as if the user is in a customized environment where common sources of information such as /etc/os-release or `XDG_SESSION_DESKTOP` are unavailable, empty or incorrectly populated with unusual values, but the user is sure that the environment is compatible with keyszer. 

Nothing in current main is designed to use this information, but Wayland support will require it. This will be the bypass to get keyszer working if the environment detection algorithm fails for any reason. Might be required if the user is using a system-level systemd service file running as another user, and the environment is Wayland. 