### PR TITLE
Register looptime mark to avoid warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 asyncio_mode = auto
+markers = looptime


### PR DESCRIPTION
Register's `looptime` mark in `pytest.ini` to suppress `PytestUnknownMarkWarning` lines in terminal output when running `pytest`. 
