### PR TITLE
Update xorg_mock.py get rid of `wm_name` errors in pytest

### DIFF
--- a/tests/lib/xorg_mock.py
+++ b/tests/lib/xorg_mock.py
@@ -1,13 +1,16 @@
 _window = None
-
+_wm_name = None
 
 def get_xorg_context():
     return {
         "wm_class": _window or "",
+        "wm_name": _wm_name or "",
         "x_error": False
     }
 
 
 def set_window(x):
     global _window
+    global _wm_name
     _window = x
+    _wm_name = x


### PR DESCRIPTION
<!--- Provide a quick summary of your changes in the Title above -->

### Changes

Add `wm_name` as an attribute of the mock `xorg` context, to get rid of a bunch of `pytest` errors complaining about `wm_name`. 

