### PR TITLE
(DRAFT) Pass context to additional handle_commands instances

### DIFF
--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -589,13 +589,13 @@ def handle_commands(commands, key, action, input_combo=None):
             elif isinstance(command, Keymap):
                 keymap = command
                 if Trigger.IMMEDIATELY in keymap:
-                    handle_commands(keymap[Trigger.IMMEDIATELY], None, None)
+                    handle_commands(keymap[Trigger.IMMEDIATELY], None, None, ctx)
                 _active_keymaps = [keymap]
                 return False
             # to_keystrokes and unicode_keystrokes produce lists so
             # we'll just handle it recursively
             elif isinstance(command, list):
-                reset_mode = handle_commands(command, key, action)
+                reset_mode = handle_commands(command, key, action, ctx)
                 if reset_mode is False:
                     return False
             elif command is None:


### PR DESCRIPTION
<!--- Provide a quick summary of your changes in the Title above -->

### Changes

Two additional instances of `handle_commands` need to be passing the context object that is now required in the function definition. One instance (trigger immediately) has been tested. The other instance, which may no longer be called after I changed the string and Unicode processor helper functions to return inner functions, I'm not sure how to test. 

So I'm marking this as a DRAFT. 

Fixing the first instance also fixes an error when running `pytest`. 
