### PR TITLE
Update api.py, add `leds()` method to mock keyboard

### DIFF
--- a/tests/lib/api.py
+++ b/tests/lib/api.py
@@ -7,7 +7,11 @@ from keyszer.transform import on_event
 
 class MockKeyboard:
     name = "generic keyboard"
-
+    device = "/dev/input/event99"
+    phys = "isa0060/serio0/input99"
+    
+    def leds(self):
+        return []
 
 _kb = MockKeyboard()
 


### PR DESCRIPTION
<!--- Provide a quick summary of your changes in the Title above -->

### Changes

Add a more complete definition of the mock keyboard device, and give it an `leds()` method that returns a list, to remove errors about the mock keyboard not having an `leds` attribute. 
