### PR TITLE
Clarify logging of ComboHint

### DIFF
--- a/src/keyszer/models/combo.py
+++ b/src/keyszer/models/combo.py
@@ -13,6 +13,9 @@ class ComboHint(IntEnum):
     ESCAPE_NEXT = 2
     IGNORE = 3
 
+    def __str__(self):
+        return self.__repr__()
+
 
 class Combo:
     def __init__(self, modifiers, key):


### PR DESCRIPTION
ComboHint attributes such as ComboHint.IGNORE are often used alone in the config file, and in the log would be shown as their literal value (in this case "3"). This is a source of confusion in the logging. 

The update should cause the attributes of ComboHint to be shown in the log in the same <EnumName.EnumMember: value> format that occurs when the they are part of a macro/list construct, even when they are used alone.
