### PR TITLE
environ_api and window context provider classes module

### DIFF
--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -66,6 +66,7 @@ def environ_api(session_type='x11', wl_desktop_env=None):
     # disregard any capitalization mistakes by user
     if isinstance(session_type, str):
         session_type = session_type.casefold()
+
     if isinstance(wl_desktop_env, str):
         wl_desktop_env = wl_desktop_env.casefold()
 

--- a/src/keyszer/config_api.py
+++ b/src/keyszer/config_api.py
@@ -41,6 +41,57 @@ TIMEOUT_DEFAULTS = {
 # multipurpose timeout
 _TIMEOUTS = TIMEOUT_DEFAULTS
 
+valid_session_types = ['x11', 'wayland']
+valid_wl_desktop_envs = ['gnome']
+
+_ENVIRON = {
+        'session_type'  : 'x11',
+        'wl_desktop_env': None
+}
+
+
+def environ_api(session_type='x11', wl_desktop_env=None):
+    """
+    API function to specify the session type (X11/Xorg or Wayland)
+    and if Wayland, which desktop environment, to be used to try 
+    to instantiate the correct window context provider object.
+    
+    Supported Wayland + desktop environment combinations:
+        - Wayland + GNOME (shell extension required)
+
+    Default session type is 'x11' for backwards compatibility
+    with existing configs not using the API.
+    """
+
+    # disregard any capitalization mistakes by user
+    if isinstance(session_type, str):
+        session_type = session_type.casefold()
+    if isinstance(wl_desktop_env, str):
+        wl_desktop_env = wl_desktop_env.casefold()
+
+    if session_type not in valid_session_types:
+        error( f'Invalid session type: {session_type}')
+        debug(  f'Valid session types for keyszer are:'
+                f'\n\t{valid_session_types}')
+        sys.exit(1)
+
+    if wl_desktop_env not in valid_wl_desktop_envs:
+        error(f'Invalid Wayland desktop environment: {wl_desktop_env}')
+        debug(  f'Valid Wayland desktop environments for keyszer are:'
+                f'\n\t{valid_wl_desktop_envs}')
+        sys.exit(1)
+
+    if wl_desktop_env and session_type != 'wayland':
+        wl_desktop_env = None
+        debug(f"API arg 'wl_desktop_env' ignored if session_type is not 'wayland'")
+
+    _ENVIRON.update({
+        'session_type': session_type,
+        'desktop_env' : wl_desktop_env
+    })
+    debug(  f"ENVIRON: Session type: '{session_type}', Desktop env: '{wl_desktop_env}'")
+
+
 # global dict of delay values used to mitigate Unicode entry sequence and macro or combo failures
 THROTTLE_DELAY_DEFAULTS = {
     'key_pre_delay_ms': 0,

--- a/src/keyszer/lib/key_context.py
+++ b/src/keyszer/lib/key_context.py
@@ -1,16 +1,21 @@
 from ..xorg import get_xorg_context
 from ..models.key import Key
+from .window_context import WindowContextProvider
 
 
 class KeyContext:
-    def __init__(self, device):
+    def __init__(self, device, session_type, wl_desktop_env):
         self._X_ctx = None
         self._device = device
+        self.session_type = session_type
+        self.wl_desktop_env = wl_desktop_env
+        self._win_ctx_provider = WindowContextProvider(self.session_type, self.wl_desktop_env)
 
     def _query_window_context(self):
         # cache this,  think it might be expensive
         if self._X_ctx is None:
-            self._X_ctx = get_xorg_context()
+            # self._X_ctx = get_xorg_context()
+            self._X_ctx = self._win_ctx_provider.get_window_context()
 
     @property
     def wm_class(self):

--- a/src/keyszer/lib/key_context.py
+++ b/src/keyszer/lib/key_context.py
@@ -1,4 +1,4 @@
-from ..xorg import get_xorg_context
+# from ..xorg import get_xorg_context
 from ..models.key import Key
 from .window_context import WindowContextProvider
 

--- a/src/keyszer/lib/window_context.py
+++ b/src/keyszer/lib/window_context.py
@@ -1,0 +1,206 @@
+import abc
+import json
+from .logger import error, debug
+
+# Provider classes for window context info
+
+NO_CONTEXT_WAS_ERROR = {"wm_class": "", "wm_name": "", "x_error": True}
+
+
+
+class WindowContextProviderInterface(abc.ABC):
+
+    @abc.abstractmethod
+    def get_window_context(self):
+        pass
+
+
+class WindowContextProvider(WindowContextProviderInterface):
+    """generic object to provide correct window context to KeyContext"""
+
+    def __init__(self, session_type, wl_desktop_env) -> None:
+        if session_type == 'x11':
+            self._provider = Xorg_WindowContext()
+        if session_type == 'wayland' and wl_desktop_env == 'gnome':
+            self._provider = Wl_GNOME_WindowContext()
+        # TODO: Add more compatible providers here in future
+        # Next up: Wayland + KDE Plasma
+
+    def get_window_context(self):
+        return self._provider.get_window_context()
+
+
+class Wl_GNOME_WindowContext(WindowContextProviderInterface):
+    """Window context provider object for Wayland+GNOME environments"""
+
+    def __init__(self):
+        import dbus
+        from dbus.exceptions import DBusException
+
+        self.DBusException      = DBusException
+        self.session_bus        = dbus.SessionBus()
+
+        self.proxy_xremap       = self.session_bus.get_object(
+                                                        "org.gnome.Shell",
+                                                        "/com/k0kubun/Xremap")
+        self.iface_xremap       = dbus.Interface(
+                                            self.proxy_xremap,
+                                            "com.k0kubun.Xremap")
+        self.proxy_windowsext   = self.session_bus.get_object(
+                                                        "org.gnome.Shell",
+                                                        "/org/gnome/Shell/Extensions/WindowsExt")
+        self.iface_windowsext   = dbus.Interface(
+                                            self.proxy_windowsext,
+                                            "org.gnome.Shell.Extensions.WindowsExt")
+
+        self.last_shell_ext_uuid    = None
+        self.ext_uuid_windowsext    = 'window-calls-extended@hseliger.eu'
+        self.ext_uuid_xremap        = 'xremap@k0kubun.com'
+
+        self.GNOME_SHELL_EXTENSIONS = {
+            self.ext_uuid_windowsext:   self.get_wl_gnome_dbus_windowsext_context,
+            self.ext_uuid_xremap:       self.get_wl_gnome_dbus_xremap_context,
+        }
+
+    def get_window_context(self):
+        """
+        This function gets the window context from one of the two compatible 
+        GNOME Shell extensions, via D-Bus.
+        
+        It attempts to get the window context from the shell extension that 
+        was successfully used last time.
+        
+        If it fails, it tries the other one. If both fail, it returns an error.
+        """
+
+        # Order of the extensions
+        extension_order = [self.ext_uuid_windowsext, self.ext_uuid_xremap]
+
+        # If we don't have a successful previous extension or it was the last in the order
+        if (self.last_shell_ext_uuid not in extension_order
+            or extension_order.index(self.last_shell_ext_uuid) == len(extension_order) - 1):
+            starting_index  = 0  # We start from the first extension
+        else:
+            # We start from the next extension
+            starting_index  = extension_order.index(self.last_shell_ext_uuid) + 1
+
+        for i in range(starting_index, len(extension_order)):
+            extension_uuid  = extension_order[i]
+            try:
+                # Call the function associated with the extension
+                context     = self.GNOME_SHELL_EXTENSIONS[extension_uuid]()
+            except self.DBusException as e:
+                self.last_shell_ext_uuid = None
+                error(f'Error returned from GNOME Shell extension {extension_uuid}\n\t {e}')
+            else:
+                self.last_shell_ext_uuid = extension_uuid
+                debug(f"SHELL_EXT: Using '{self.last_shell_ext_uuid}' for window context")
+                return context
+
+        # If we reach here, it means all extensions have failed
+        print()
+        error(  f'############################################################################'
+                f'\nSHELL_EXT: No compatible GNOME Shell extension responding via D-Bus.')
+        error(  f'These extensions are compatible with keyszer:'
+                f'\n       {self.ext_uuid_windowsext}:'
+                f'\n\t\t(https://extensions.gnome.org/extension/4974/window-calls-extended/)'
+                f'\n       {self.ext_uuid_xremap}:'
+                f'\n\t\t(https://extensions.gnome.org/extension/5060/xremap/)'  )
+        error(f'Install "Extension Manager" from Flathub to manage GNOME Shell extensions')
+        error(f'############################################################################')
+        print()
+        return NO_CONTEXT_WAS_ERROR
+
+
+    def get_wl_gnome_dbus_xremap_context(self):
+        active_window_dbus  = ""
+        active_window_dct   = ""
+        wm_class            = ""
+        wm_name             = ""
+
+        active_window_dbus  = self.iface_xremap.ActiveWindow()
+        active_window_dct   = json.loads(active_window_dbus)
+        wm_class            = active_window_dct['wm_class']
+        wm_name             = active_window_dct['title']
+
+        return {"wm_class": wm_class, "wm_name": wm_name, "context_error": False}
+
+    def get_wl_gnome_dbus_windowsext_context(self):
+        wm_class            = ""
+        wm_name             = ""
+
+        wm_class            = str(self.iface_windowsext.FocusClass())
+        wm_name             = str(self.iface_windowsext.FocusTitle())
+
+        return {"wm_class": wm_class, "wm_name": wm_name, "context_error": False}
+
+
+class Xorg_WindowContext(WindowContextProviderInterface):
+    """Window context provider object for X11/Xorg environments"""
+
+    def __init__(self):
+        self._display = None
+
+        # Import Xlib modules here
+        from Xlib.xobject.drawable import Window
+        from Xlib.display import Display
+        from Xlib.error import (ConnectionClosedError, DisplayConnectionError, DisplayNameError)
+        self.Window                 = Window
+        self.Display                = Display
+        self.ConnectionClosedError  = ConnectionClosedError
+        self.DisplayConnectionError = DisplayConnectionError
+        self.DisplayNameError       = DisplayNameError
+
+    def get_window_context(self):
+        """
+        Get window context from Xorg, window name, class,
+        whether there is an X error or not
+        """
+        try:
+            self._display = self._display or self.Display()
+            wm_class    = ""
+            wm_name     = ""
+
+            input_focus = self._display.get_input_focus().focus
+            window      = self.get_actual_window(input_focus)
+            if window:
+                # use _NET_WM_NAME string instead of WM_NAME to 
+                # bypass (COMPOUND_TEXT) encoding problems
+                wm_name = window.get_full_text_property(self._display.get_atom("_NET_WM_NAME"))
+                pair    = window.get_wm_class()
+                if pair:
+                    wm_class = str(pair[1])
+
+            return {"wm_class": wm_class, "wm_name": wm_name, "x_error": False}
+
+        except self.ConnectionClosedError as xerror:
+            error(xerror)
+            self._display = None
+            return NO_CONTEXT_WAS_ERROR
+        # most likely DISPLAY env isn't even set
+        except self.DisplayNameError as xerror:
+            error(xerror)
+            self._display = None
+            return NO_CONTEXT_WAS_ERROR
+        # seen when we don't have permission to the X display
+        except self.DisplayConnectionError as xerror:
+            error(xerror)
+            self._display = None
+            return NO_CONTEXT_WAS_ERROR
+
+    def get_actual_window(self, window):
+        if not isinstance(window, self.Window):
+            return None
+
+        # use _NET_WM_NAME string instead of WM_NAME to bypass (COMPOUND_TEXT) encoding problems
+        wmname = window.get_full_text_property(self._display.get_atom("_NET_WM_NAME"))
+        wmclass = window.get_wm_class()
+        # workaround for Java app
+        # https://github.com/JetBrains/jdk8u_jdk/blob/master/src/solaris/classes/sun/awt/X11/XFocusProxyWindow.java#L35
+        if (wmclass is None and wmname is None) or "FocusProxy" in (wmclass or ""):
+            parent_window = window.query_tree().parent
+            if parent_window:
+                return self.get_actual_window(parent_window)
+            return None
+
+        return window

--- a/src/keyszer/lib/window_context.py
+++ b/src/keyszer/lib/window_context.py
@@ -7,7 +7,6 @@ from .logger import error, debug
 NO_CONTEXT_WAS_ERROR = {"wm_class": "", "wm_name": "", "x_error": True}
 
 
-
 class WindowContextProviderInterface(abc.ABC):
 
     @abc.abstractmethod

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -3,7 +3,7 @@ import time
 
 from evdev import ecodes
 
-from .config_api import escape_next_key, get_configuration, ignore_key
+from .config_api import escape_next_key, get_configuration, ignore_key, _ENVIRON
 from .lib import logger
 from .lib.key_context import KeyContext
 from .lib.logger import debug
@@ -324,11 +324,14 @@ def find_keystate_or_new(inkey, action):
 def on_event(event, device):
     # we do not attempt to transform non-key events
     # or any events with no device (startup key-presses)
-    if event.type != ecodes.EV_KEY or device == None:
+    if event.type != ecodes.EV_KEY or device is None:
         _output.send_event(event)
         return
 
-    context = KeyContext(device)
+    session_type    = _ENVIRON['session_type']
+    wl_desktop_env  = _ENVIRON['wl_desktop_env']
+
+    context = KeyContext(device, session_type, wl_desktop_env)
     action = Action(event.value)
     key = Key(event.code)
 

--- a/src/keyszer/transform.py
+++ b/src/keyszer/transform.py
@@ -328,6 +328,7 @@ def on_event(event, device):
         _output.send_event(event)
         return
 
+
     session_type    = _ENVIRON['session_type']
     wl_desktop_env  = _ENVIRON['wl_desktop_env']
 


### PR DESCRIPTION
<!--- Provide a quick summary of your changes in the Title above -->

### Changes

This PR contains a new API function, to allow the user to specify a session type and (Wayland) desktop environment, from limited lists, to be given as parameters to `KeyContext` when creating the context object. `KeyContext` in turn creates an instance of a "window context provider" class object while giving it the same parameters, which internally re-routes to the correct provider class object for the given environment, without `KeyContext` needing to know anything else. 

Provides support for X11/Xorg and Wayland+GNOME environments (with the installation of either of the compatible GNOME Shell extensions). 

Adding future providers will mean adding a new class in `window_context.py` and adding to the lists in `config_api.py` used by the API function to verify that the environment choice is valid, then pointing the logic in the generic provider class to the correct new provider class with the actual code to get the job done. 

**Checklist**

- [ ] Added tests (if necessary)
- [ ] Updated docs or README...
