### PR TITLE
Add more mouse button events

### DIFF
--- a/src/keyszer/output.py
+++ b/src/keyszer/output.py
@@ -28,8 +28,10 @@ _MOUSE_BUTTONS = {
     264: "BTN_8",
     265: "BTN_9",
     272: ["BTN_LEFT", "BTN_MOUSE"],
-    274: "BTN_MIDDLE",
     273: "BTN_RIGHT",
+    274: "BTN_MIDDLE",
+    275: "BTN_SIDE",
+    276: "BTN_EXTRA",
 }
 _KEYBOARD_KEYS.update(_MOUSE_BUTTONS)
 


### PR DESCRIPTION
@joshgoebel 

Logitech MX Master 3 **_mouse_** (not a keyboard) has additional buttons on the side that get blocked from operation while `keyszer` is active. Adding the 275, 276 events to the pass-through list lets the buttons work again. 

User of the device states that the buttons perform back/forward page navigation in Firefox when they are working, and tested the fix with good results.

Ref: https://github.com/RedBearAK/toshy/issues/7
