### PR TITLE
Quote device name string when grabbing/ungrabbing

### DIFF
--- a/src/keyszer/devices.py
+++ b/src/keyszer/devices.py
@@ -81,7 +81,7 @@ class DeviceRegistry:
             self.grab(device)
 
     def grab(self, device):
-        info(f"Grabbing {device.name} ({device.fn})", ctx="+K")
+        info(f"Grabbing '{device.name}' ({device.fn})", ctx="+K")
         self._loop.add_reader(device, self._input_cb, device)
         self._devices.append(device)
         try:
@@ -93,7 +93,7 @@ class DeviceRegistry:
             raise DeviceGrabError()
 
     def ungrab(self, device):
-        info(f"Ungrabbing: {device.name} (removed)", ctx="-K")
+        info(f"Ungrabbing: '{device.name}' (removed)", ctx="-K")
         self._loop.remove_reader(device)
         self._devices.remove(device)
         try:
@@ -105,7 +105,7 @@ class DeviceRegistry:
         for device in self._devices:
             try:
                 if device.fn == fn:
-                    info(f"Ungrabbing: {device.name} (removed)", ctx="-K")
+                    info(f"Ungrabbing: '{device.name}' (removed)", ctx="-K")
                     self._loop.remove_reader(device)
                     self._devices.remove(device)
                     device.ungrab()

--- a/src/keyszer/devices.py
+++ b/src/keyszer/devices.py
@@ -93,7 +93,7 @@ class DeviceRegistry:
             raise DeviceGrabError()
 
     def ungrab(self, device):
-        info(f"Ungrabbing: '{device.name}' (removed)", ctx="-K")
+        info(f"Ungrabbing '{device.name}' (removed)", ctx="-K")
         self._loop.remove_reader(device)
         self._devices.remove(device)
         try:
@@ -105,7 +105,7 @@ class DeviceRegistry:
         for device in self._devices:
             try:
                 if device.fn == fn:
-                    info(f"Ungrabbing: '{device.name}' (removed)", ctx="-K")
+                    info(f"Ungrabbing '{device.name}' (removed)", ctx="-K")
                     self._loop.remove_reader(device)
                     self._devices.remove(device)
                     device.ungrab()


### PR DESCRIPTION
It can be confusing when the device name string includes something generic like 'keyboard', which can seem like just part of the logging. Quotes around the actual device name string when grabbing or ungrabbing the device will alleviate this. 

Example using my keyboard device name: 

(+K) Grabbing AT Translated Set 2 keyboard (/dev/input/event4)

(+K) Grabbing 'AT Translated Set 2 keyboard' (/dev/input/event4)

The device name is not 'AT Translated Set 2', which might be a natural assumption, but 'AT Translated Set 2 keyboard', which will be made clearer by adding the quotes.

<!--- Provide a quick summary of your changes in the Title above -->

### Changes

<!-- Reference a related issue (if one exists) so things are linked nicely: -->

<!-- `Resolves #12345`, etc. Then describe your changes... -->

**Checklist**

- [ ] Added tests (if necessary)
- [ ] Updated docs or README...
